### PR TITLE
feat(tools): add GRF Browser GUI tool (Stage 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.22'
+  GO_VERSION: '1.24'
 
 jobs:
   build:
@@ -36,7 +36,9 @@ jobs:
         run: go build -v ./cmd/client
 
       - name: Build tools
-        run: go build -v ./cmd/grftool
+        run: |
+          go build -v ./cmd/grftool
+          go build -v ./cmd/grfbrowser
 
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ pkg/formats/testdata/duckling.spr
 Thumbs.db
 ehthumbs.db
 Desktop.ini
+
+# ImGui
+imgui.ini

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,12 @@ build-debug: ## Build with debug symbols
 	go build $(GOFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-debug $(CMD_DIR)
 	@echo "Built: $(BUILD_DIR)/$(BINARY_NAME)-debug"
 
-build-tools: ## Build CLI tools (grftool)
+build-tools: ## Build CLI tools (grftool, grfbrowser)
 	@echo "Building tools..."
 	@mkdir -p $(BUILD_DIR)
 	go build $(GOFLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/grftool ./cmd/grftool
-	@echo "Built: $(BUILD_DIR)/grftool"
+	go build $(GOFLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/grfbrowser ./cmd/grfbrowser
+	@echo "Built: $(BUILD_DIR)/grftool, $(BUILD_DIR)/grfbrowser"
 
 ## Run
 

--- a/cmd/grfbrowser/main.go
+++ b/cmd/grfbrowser/main.go
@@ -1,0 +1,582 @@
+// GRF Browser - A graphical tool for browsing Ragnarok Online GRF archives.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/AllenDang/cimgui-go/backend"
+	"github.com/AllenDang/cimgui-go/backend/sdlbackend"
+	"github.com/AllenDang/cimgui-go/imgui"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/transform"
+
+	"github.com/Faultbox/midgard-ro/pkg/grf"
+)
+
+func main() {
+	runtime.LockOSThread()
+
+	// Parse command line arguments
+	grfPath := flag.String("grf", "", "Path to GRF file to open")
+	flag.Parse()
+
+	// Create and run application
+	app := NewApp()
+	defer app.Close()
+
+	// Open GRF if specified
+	if *grfPath != "" {
+		if err := app.OpenGRF(*grfPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening GRF: %v\n", err)
+		}
+	}
+
+	app.Run()
+}
+
+// App represents the GRF Browser application state.
+type App struct {
+	backend backend.Backend[sdlbackend.SDLWindowFlags]
+
+	// GRF state
+	archive     *grf.Archive
+	grfPath     string
+	fileTree    *FileNode
+	flatFiles   []string
+	totalFiles  int
+	filterCount int
+
+	// UI state
+	searchText    string
+	selectedPath  string
+	expandedPaths map[string]bool
+
+	// Filter state
+	filterSprites    bool
+	filterAnimations bool
+	filterTextures   bool
+	filterModels     bool
+	filterMaps       bool
+	filterAudio      bool
+	filterOther      bool
+}
+
+// FileNode represents a node in the virtual file tree.
+type FileNode struct {
+	Name     string
+	Path     string
+	IsDir    bool
+	Children []*FileNode
+	Size     int64
+}
+
+// NewApp creates a new application instance.
+func NewApp() *App {
+	app := &App{
+		expandedPaths:    make(map[string]bool),
+		filterSprites:    true,
+		filterAnimations: true,
+		filterTextures:   true,
+		filterModels:     true,
+		filterMaps:       true,
+		filterAudio:      true,
+		filterOther:      true,
+	}
+
+	// Create backend using the proper wrapper
+	var err error
+	app.backend, err = backend.CreateBackend(sdlbackend.NewSDLBackend())
+	if err != nil {
+		panic(fmt.Sprintf("failed to create backend: %v", err))
+	}
+
+	app.backend.SetBgColor(imgui.NewVec4(0.1, 0.1, 0.12, 1.0))
+	app.backend.CreateWindow("GRF Browser", 1280, 800)
+
+	return app
+}
+
+// Close cleans up resources.
+func (app *App) Close() {
+	if app.archive != nil {
+		app.archive.Close()
+	}
+}
+
+// Run starts the main application loop.
+func (app *App) Run() {
+	app.backend.Run(app.render)
+}
+
+// OpenGRF opens a GRF archive file.
+func (app *App) OpenGRF(path string) error {
+	// Close existing archive
+	if app.archive != nil {
+		app.archive.Close()
+	}
+
+	// Open new archive
+	archive, err := grf.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open GRF: %w", err)
+	}
+
+	app.archive = archive
+	app.grfPath = path
+	app.flatFiles = archive.List()
+	app.totalFiles = len(app.flatFiles)
+	app.fileTree = app.buildFileTree()
+	app.filterCount = app.totalFiles
+	app.selectedPath = ""
+	app.expandedPaths = make(map[string]bool)
+
+	// Update window title
+	app.backend.SetWindowTitle(fmt.Sprintf("GRF Browser - %s", filepath.Base(path)))
+
+	return nil
+}
+
+// buildFileTree creates a virtual folder structure from flat file list.
+func (app *App) buildFileTree() *FileNode {
+	root := &FileNode{
+		Name:     "root",
+		Path:     "",
+		IsDir:    true,
+		Children: make([]*FileNode, 0),
+	}
+
+	// Map to track created directories
+	dirs := make(map[string]*FileNode)
+	dirs[""] = root
+
+	// Sort files for consistent ordering
+	sortedFiles := make([]string, len(app.flatFiles))
+	copy(sortedFiles, app.flatFiles)
+	sort.Strings(sortedFiles)
+
+	for _, filePath := range sortedFiles {
+		// Apply filters
+		if !app.matchesFilter(filePath) {
+			continue
+		}
+
+		// Apply search
+		if app.searchText != "" && !app.matchesSearch(filePath) {
+			continue
+		}
+
+		// Normalize path and convert from EUC-KR to UTF-8
+		normalizedPath := strings.ReplaceAll(filePath, "\\", "/")
+		normalizedPath = euckrToUTF8(normalizedPath)
+		parts := strings.Split(normalizedPath, "/")
+
+		// Create parent directories
+		currentPath := ""
+		parent := root
+
+		for i, part := range parts {
+			if i < len(parts)-1 {
+				// Directory
+				if currentPath != "" {
+					currentPath += "/"
+				}
+				currentPath += part
+
+				if existing, ok := dirs[currentPath]; ok {
+					parent = existing
+				} else {
+					newDir := &FileNode{
+						Name:     part,
+						Path:     currentPath,
+						IsDir:    true,
+						Children: make([]*FileNode, 0),
+					}
+					parent.Children = append(parent.Children, newDir)
+					dirs[currentPath] = newDir
+					parent = newDir
+				}
+			} else {
+				// File
+				fileNode := &FileNode{
+					Name:  part,
+					Path:  normalizedPath,
+					IsDir: false,
+				}
+				parent.Children = append(parent.Children, fileNode)
+			}
+		}
+	}
+
+	// Sort children at each level
+	app.sortTree(root)
+
+	return root
+}
+
+// sortTree recursively sorts children (directories first, then alphabetically).
+func (app *App) sortTree(node *FileNode) {
+	sort.Slice(node.Children, func(i, j int) bool {
+		// Directories first
+		if node.Children[i].IsDir != node.Children[j].IsDir {
+			return node.Children[i].IsDir
+		}
+		// Then alphabetically
+		return strings.ToLower(node.Children[i].Name) < strings.ToLower(node.Children[j].Name)
+	})
+
+	for _, child := range node.Children {
+		if child.IsDir {
+			app.sortTree(child)
+		}
+	}
+}
+
+// matchesFilter checks if a file matches the current type filters.
+func (app *App) matchesFilter(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+
+	switch ext {
+	case ".spr":
+		return app.filterSprites
+	case ".act":
+		return app.filterAnimations
+	case ".bmp", ".tga", ".jpg", ".png", ".imf":
+		return app.filterTextures
+	case ".rsm":
+		return app.filterModels
+	case ".rsw", ".gat", ".gnd":
+		return app.filterMaps
+	case ".wav", ".mp3":
+		return app.filterAudio
+	default:
+		return app.filterOther
+	}
+}
+
+// matchesSearch checks if a file matches the search pattern.
+func (app *App) matchesSearch(path string) bool {
+	if app.searchText == "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(path), strings.ToLower(app.searchText))
+}
+
+// countFilteredFiles counts files matching current filters.
+func (app *App) countFilteredFiles() int {
+	count := 0
+	for _, path := range app.flatFiles {
+		if app.matchesFilter(path) && app.matchesSearch(path) {
+			count++
+		}
+	}
+	return count
+}
+
+// render is called each frame to draw the UI.
+func (app *App) render() {
+	// Handle keyboard shortcuts
+	// Ctrl+C = copy filename only
+	// Cmd+Ctrl+C = copy full path (macOS friendly)
+	if app.selectedPath != "" {
+		ctrlC := imgui.KeyChord(imgui.ModCtrl) | imgui.KeyChord(imgui.KeyC)
+		cmdCtrlC := imgui.KeyChord(imgui.ModSuper) | imgui.KeyChord(imgui.ModCtrl) | imgui.KeyChord(imgui.KeyC)
+
+		if imgui.IsKeyChordPressed(cmdCtrlC) {
+			imgui.SetClipboardText(app.selectedPath)
+		} else if imgui.IsKeyChordPressed(ctrlC) {
+			imgui.SetClipboardText(filepath.Base(app.selectedPath))
+		}
+	}
+
+	// Main menu bar
+	if imgui.BeginMainMenuBar() {
+		if imgui.BeginMenu("File") {
+			if imgui.MenuItemBool("Open GRF...") {
+				// File dialog will be implemented in Stage 2
+				// For now, use: ./grfbrowser -grf path/to/file.grf
+				_ = true // Placeholder to avoid empty branch warning
+			}
+			imgui.Separator()
+			if imgui.MenuItemBool("Exit") {
+				os.Exit(0)
+			}
+			imgui.EndMenu()
+		}
+		imgui.EndMainMenuBar()
+	}
+
+	// Get viewport work area (excludes menu bar)
+	viewport := imgui.MainViewport()
+	workPos := viewport.WorkPos()
+	workSize := viewport.WorkSize()
+
+	// Layout dimensions
+	leftPanelWidth := float32(350)
+	statusBarHeight := float32(30)
+	contentHeight := workSize.Y - statusBarHeight
+
+	// Window flags for fixed panels
+	flags := imgui.WindowFlagsNoMove | imgui.WindowFlagsNoResize | imgui.WindowFlagsNoCollapse
+
+	// Left panel - File browser
+	imgui.SetNextWindowPos(workPos)
+	imgui.SetNextWindowSize(imgui.NewVec2(leftPanelWidth, contentHeight))
+	if imgui.BeginV("Files", nil, flags) {
+		app.renderSearchAndFilter()
+		imgui.Separator()
+		app.renderFileTree()
+	}
+	imgui.End()
+
+	// Right panel - Preview
+	imgui.SetNextWindowPos(imgui.NewVec2(workPos.X+leftPanelWidth, workPos.Y))
+	imgui.SetNextWindowSize(imgui.NewVec2(workSize.X-leftPanelWidth, contentHeight))
+	if imgui.BeginV("Preview", nil, flags) {
+		app.renderPreview()
+	}
+	imgui.End()
+
+	// Status bar at bottom
+	imgui.SetNextWindowPos(imgui.NewVec2(workPos.X, workPos.Y+contentHeight))
+	imgui.SetNextWindowSize(imgui.NewVec2(workSize.X, statusBarHeight))
+	statusFlags := flags | imgui.WindowFlagsNoTitleBar | imgui.WindowFlagsNoScrollbar
+	if imgui.BeginV("##StatusBar", nil, statusFlags) {
+		app.renderStatusBar()
+	}
+	imgui.End()
+}
+
+// renderSearchAndFilter renders the search box and filter checkboxes.
+func (app *App) renderSearchAndFilter() {
+	// Search input
+	imgui.Text("Search:")
+	imgui.SameLine()
+
+	imgui.SetNextItemWidth(-1)
+	if imgui.InputTextWithHint("##search", "Filter files...", &app.searchText, 0, nil) {
+		app.rebuildTree()
+	}
+
+	// Filter checkboxes in two columns using table
+	if imgui.TreeNodeExStrV("Filters", imgui.TreeNodeFlagsDefaultOpen) {
+		changed := false
+
+		if imgui.BeginTable("filterTable", 2) {
+			imgui.TableNextRow()
+			imgui.TableNextColumn()
+			if imgui.Checkbox("Sprites", &app.filterSprites) {
+				changed = true
+			}
+			imgui.TableNextColumn()
+			if imgui.Checkbox("Models", &app.filterModels) {
+				changed = true
+			}
+
+			imgui.TableNextRow()
+			imgui.TableNextColumn()
+			if imgui.Checkbox("Animations", &app.filterAnimations) {
+				changed = true
+			}
+			imgui.TableNextColumn()
+			if imgui.Checkbox("Maps", &app.filterMaps) {
+				changed = true
+			}
+
+			imgui.TableNextRow()
+			imgui.TableNextColumn()
+			if imgui.Checkbox("Textures", &app.filterTextures) {
+				changed = true
+			}
+			imgui.TableNextColumn()
+			if imgui.Checkbox("Other", &app.filterOther) {
+				changed = true
+			}
+
+			imgui.TableNextRow()
+			imgui.TableNextColumn()
+			if imgui.Checkbox("Audio", &app.filterAudio) {
+				changed = true
+			}
+
+			imgui.EndTable()
+		}
+
+		if changed {
+			app.rebuildTree()
+		}
+
+		imgui.TreePop()
+	}
+}
+
+// rebuildTree rebuilds the file tree after filter/search changes.
+func (app *App) rebuildTree() {
+	if app.archive != nil {
+		app.fileTree = app.buildFileTree()
+		app.filterCount = app.countFilteredFiles()
+	}
+}
+
+// renderFileTree renders the file tree view.
+func (app *App) renderFileTree() {
+	if app.archive == nil {
+		imgui.TextDisabled("No GRF loaded")
+		imgui.TextDisabled("Use File > Open GRF...")
+		return
+	}
+
+	// File tree in child window for scrolling
+	if imgui.BeginChildStrV("FileTreeChild", imgui.NewVec2(0, 0), imgui.ChildFlagsBorders, imgui.WindowFlagsHorizontalScrollbar) {
+		app.renderTreeNode(app.fileTree)
+	}
+	imgui.EndChild()
+}
+
+// renderTreeNode recursively renders a tree node.
+func (app *App) renderTreeNode(node *FileNode) {
+	for _, child := range node.Children {
+		if child.IsDir {
+			// Directory node
+			flags := imgui.TreeNodeFlagsOpenOnArrow | imgui.TreeNodeFlagsOpenOnDoubleClick
+
+			// Check if expanded
+			if app.expandedPaths[child.Path] {
+				flags |= imgui.TreeNodeFlagsDefaultOpen
+			}
+
+			// Folder icon (text-based for font compatibility)
+			open := imgui.TreeNodeExStrV("[+] "+child.Name, flags)
+
+			// Track expansion state
+			if open {
+				app.expandedPaths[child.Path] = true
+				app.renderTreeNode(child)
+				imgui.TreePop()
+			} else {
+				app.expandedPaths[child.Path] = false
+			}
+		} else {
+			// File node (leaf)
+			flags := imgui.TreeNodeFlagsLeaf | imgui.TreeNodeFlagsNoTreePushOnOpen
+
+			// Selection state
+			if child.Path == app.selectedPath {
+				flags |= imgui.TreeNodeFlagsSelected
+			}
+
+			// File icon based on type
+			icon := app.getFileIcon(child.Name)
+
+			imgui.TreeNodeExStrV(icon+" "+child.Name, flags)
+
+			if imgui.IsItemClicked() {
+				app.selectedPath = child.Path
+			}
+		}
+	}
+}
+
+// getFileIcon returns an icon for a file based on its extension.
+func (app *App) getFileIcon(filename string) string {
+	ext := strings.ToLower(filepath.Ext(filename))
+
+	switch ext {
+	case ".spr":
+		return "[SPR]"
+	case ".act":
+		return "[ACT]"
+	case ".bmp", ".tga", ".jpg", ".png", ".imf":
+		return "[IMG]"
+	case ".rsm":
+		return "[3D]"
+	case ".rsw":
+		return "[MAP]"
+	case ".gat":
+		return "[GAT]"
+	case ".gnd":
+		return "[GND]"
+	case ".wav", ".mp3":
+		return "[SND]"
+	case ".txt", ".xml", ".lua":
+		return "[TXT]"
+	default:
+		return "[?]"
+	}
+}
+
+// renderPreview renders the preview panel for the selected file.
+func (app *App) renderPreview() {
+	if app.selectedPath == "" {
+		imgui.TextDisabled("Select a file to preview")
+		return
+	}
+
+	imgui.Text("Selected:")
+	imgui.TextWrapped(app.selectedPath)
+	imgui.Separator()
+
+	// Show file extension info
+	ext := strings.ToLower(filepath.Ext(app.selectedPath))
+	imgui.Text("Type: " + app.getFileTypeName(ext))
+
+	imgui.Separator()
+	imgui.TextDisabled("Preview coming in Stage 3...")
+}
+
+// getFileTypeName returns a human-readable file type name.
+func (app *App) getFileTypeName(ext string) string {
+	switch ext {
+	case ".spr":
+		return "Sprite Image"
+	case ".act":
+		return "Animation Data"
+	case ".bmp", ".tga", ".jpg", ".png":
+		return "Texture Image"
+	case ".imf":
+		return "Image Format (IMF)"
+	case ".rsm":
+		return "3D Model"
+	case ".rsw":
+		return "Map Resource"
+	case ".gat":
+		return "Ground Altitude"
+	case ".gnd":
+		return "Ground Mesh"
+	case ".wav", ".mp3":
+		return "Audio File"
+	case ".txt":
+		return "Text File"
+	case ".xml":
+		return "XML File"
+	case ".lua":
+		return "Lua Script"
+	default:
+		return "Unknown"
+	}
+}
+
+// euckrToUTF8 converts EUC-KR encoded string to UTF-8.
+func euckrToUTF8(s string) string {
+	decoder := korean.EUCKR.NewDecoder()
+	result, _, err := transform.String(decoder, s)
+	if err != nil {
+		return s // Return original if conversion fails
+	}
+	return result
+}
+
+// renderStatusBar renders the status bar at the bottom.
+func (app *App) renderStatusBar() {
+	if app.archive != nil {
+		imgui.Text(fmt.Sprintf("%d files total | %d filtered | Selected: %s",
+			app.totalFiles, app.filterCount, app.selectedPath))
+	} else {
+		imgui.Text("No GRF loaded")
+	}
+}

--- a/docs/adr/ADR-009-grf-browser-tool.md
+++ b/docs/adr/ADR-009-grf-browser-tool.md
@@ -1,0 +1,263 @@
+# ADR-009: GRF Browser Tool
+
+## Status
+Accepted
+
+## Context
+
+We need a comprehensive tool to browse, view, and eventually modify GRF archive contents. This tool will:
+1. Validate our file format parsers (SPR, ACT, and future formats)
+2. Provide a development/debugging tool for asset inspection
+3. Serve as a foundation for modding tools
+
+### Inspiration from Existing Solutions
+
+| Tool | Key Features |
+|------|--------------|
+| Unity Project Window | Dual-pane, search with filters, preview panel, favorites |
+| Unreal Content Browser | Breadcrumbs, thumbnails, property inspector, collections |
+| Godot FileSystem | Tree + inspector, quick filter, drag-drop |
+| GRF Editor (RO) | Tree view, extract/add files, sprite preview |
+| actOR2 (RO) | SPR/ACT editing, frame-by-frame preview |
+
+## Decision
+
+### 1. Technology Stack
+
+| Component | Choice | Rationale |
+|-----------|--------|-----------|
+| GUI | [Dear ImGui](https://github.com/ocornut/imgui) via [cimgui-go](https://github.com/AllenDang/cimgui-go) | Industry standard, immediate mode, highly customizable |
+| Window/Input | SDL2 | Already in use, cross-platform |
+| Rendering | OpenGL 4.1 | Already in use, texture support |
+
+### 2. Application Layout
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  GRF Browser - data.grf                                         [─][□][×]│
+├────────────────────────┬────────────────────────────────────────────────┤
+│ ┌────────────────────┐ │ ┌────────────────────────────────────────────┐ │
+│ │ 🔍 Search...       │ │ │              Preview Panel                 │ │
+│ ├────────────────────┤ │ │                                            │ │
+│ │ Filter: [All ▼]    │ │ │     ┌──────────────────────────┐          │ │
+│ │ ☑ Sprites (.spr)   │ │ │     │                          │          │ │
+│ │ ☑ Animations (.act)│ │ │     │    [Animated Sprite]     │          │ │
+│ │ ☑ Textures (.bmp)  │ │ │     │                          │          │ │
+│ │ ☑ Models (.rsm)    │ │ │     └──────────────────────────┘          │ │
+│ │ ☑ Maps (.rsw)      │ │ │                                            │ │
+│ │ ☐ Audio (.wav)     │ │ │  ◀ Action 5/56 ▶   ◀ Frame 2/4 ▶          │ │
+│ │ ☐ Other            │ │ │  [▶ Play] [⏸ Pause]  Speed: [1.0x ▼]      │ │
+│ ├────────────────────┤ │ ├────────────────────────────────────────────┤
+│ │ 📁 data            │ │ │              Properties Panel              │ │
+│ │  ├─📁 sprite       │ │ │ ┌──────────────────────────────────────┐  │ │
+│ │  │  ├─📁 npc       │ │ │ │ File: duckling.spr                   │  │ │
+│ │  │  │  ├─🖼 duck...│ │ │ │ Size: 34,098 bytes                   │  │ │
+│ │  │  │  └─🎬 duck...│ │ │ │ Version: 2.1                         │  │ │
+│ │  │  └─📁 monster   │ │ │ │ Images: 47                           │  │ │
+│ │  ├─📁 texture      │ │ │ │ Palette: Yes (256 colors)            │  │ │
+│ │  └─📁 wav          │ │ │ └──────────────────────────────────────┘  │ │
+│ └────────────────────┘ │ └────────────────────────────────────────────┘ │
+├────────────────────────┴────────────────────────────────────────────────┤
+│ 18,841 files │ Filter: 2,456 sprites │ Selected: duckling.spr          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3. Core Features
+
+#### 3.1 File Tree Panel (Left)
+- **Hierarchical tree view** of GRF contents
+- **Virtual folders** from file paths (data/sprite/npc/...)
+- **Icons** by file type (folder, sprite, animation, texture, etc.)
+- **Lazy loading** for large archives (18k+ files)
+- **Keyboard navigation**: Arrow keys, Enter to expand/select
+- **Mouse support**: Click to select, double-click to expand/preview
+
+#### 3.2 Search & Filter
+- **Live search** with `%like%` pattern matching
+- **Type filters** as checkboxes:
+  - Sprites (.spr)
+  - Animations (.act)
+  - Textures (.bmp, .tga, .jpg)
+  - Models (.rsm)
+  - Maps (.rsw, .gat, .gnd)
+  - Audio (.wav, .mp3)
+  - Other
+- **Results highlighting** in tree
+- **Search history** (last 10 searches)
+
+#### 3.3 Preview Panel (Right Top)
+File-type specific viewers:
+
+| Type | Viewer |
+|------|--------|
+| .spr | Sprite viewer with frame navigation |
+| .spr + .act | Animated sprite with playback controls |
+| .bmp/.tga | Image viewer with zoom |
+| .wav | Audio player (play/stop) |
+| .txt/.xml | Text viewer |
+| Other | Hex dump preview |
+
+#### 3.4 Properties Panel (Right Bottom)
+Metadata display:
+- File path, size, compression ratio
+- Format-specific info (SPR version, image count, etc.)
+- Timestamps (if available)
+
+#### 3.5 Status Bar
+- Total file count
+- Filtered file count
+- Current selection
+- Loading progress
+
+### 4. Controls
+
+#### Keyboard
+| Key | Action |
+|-----|--------|
+| Ctrl+O | Open GRF |
+| Ctrl+F | Focus search |
+| Ctrl+E | Extract selected |
+| ↑/↓ | Navigate tree |
+| ←/→ | Collapse/Expand folder |
+| Enter | Select/Preview |
+| Space | Play/Pause animation |
+| +/- | Zoom preview |
+| Escape | Clear search / Close dialog |
+
+#### Mouse
+- Click: Select
+- Double-click: Expand folder / Open viewer
+- Right-click: Context menu (Extract, Copy path, etc.)
+- Scroll: Navigate tree / Zoom preview
+- Drag splitter: Resize panels
+
+### 5. Development Stages
+
+#### Stage 1: Foundation (MVP)
+**Goal**: Load GRF, display tree, basic navigation
+
+- [ ] ImGui + SDL2 + OpenGL integration
+- [ ] Open GRF dialog
+- [ ] Tree view with virtual folders
+- [ ] Basic file list (no icons yet)
+- [ ] Keyboard navigation (↑↓←→)
+- [ ] Status bar with file count
+
+#### Stage 2: Search & Filter
+**Goal**: Find files efficiently
+
+- [ ] Search input with live filtering
+- [ ] Type filter checkboxes
+- [ ] Result count display
+- [ ] Search history dropdown
+- [ ] Highlight matching items
+
+#### Stage 3: Sprite Viewer
+**Goal**: Preview SPR/ACT files
+
+- [ ] SPR loading and texture creation
+- [ ] Single frame display
+- [ ] Frame navigation (←→)
+- [ ] ACT loading
+- [ ] Animation playback with timing
+- [ ] Action navigation
+- [ ] Play/Pause/Speed controls
+
+#### Stage 4: Extended Viewers
+**Goal**: Preview more file types
+
+- [ ] Image viewer (.bmp, .tga)
+- [ ] Text viewer (.txt, .xml, .lua)
+- [ ] Hex viewer (fallback)
+- [ ] Audio player (.wav)
+- [ ] Properties panel for all types
+
+#### Stage 5: Polish
+**Goal**: Production-ready UX
+
+- [ ] File type icons
+- [ ] Recent files list
+- [ ] Favorites/Bookmarks
+- [ ] Drag splitters for panel resize
+- [ ] Keyboard shortcuts overlay (?)
+- [ ] Preferences (theme, default zoom, etc.)
+
+#### Stage 6: Modification (Future)
+**Goal**: Edit and save GRF contents
+
+- [ ] Extract single file
+- [ ] Extract with folder structure
+- [ ] Extract filtered results
+- [ ] Add new files to GRF
+- [ ] Replace existing files
+- [ ] Delete files
+- [ ] Create new GRF
+- [ ] Save modified GRF
+
+### 6. Package Structure
+
+```
+cmd/grfbrowser/
+├── main.go              # Entry point, argument parsing
+├── app.go               # Application state and main loop
+├── ui/
+│   ├── ui.go            # ImGui setup and main layout
+│   ├── tree.go          # File tree panel
+│   ├── search.go        # Search and filter panel
+│   ├── preview.go       # Preview panel router
+│   ├── properties.go    # Properties panel
+│   └── dialogs.go       # Open file, extract, etc.
+└── viewers/
+    ├── sprite.go        # SPR/ACT viewer
+    ├── image.go         # BMP/TGA viewer
+    ├── text.go          # Text file viewer
+    ├── hex.go           # Hex dump viewer
+    └── audio.go         # Audio player
+```
+
+### 7. Technical Considerations
+
+#### Performance
+- **Lazy tree building**: Only expand visible nodes
+- **Texture caching**: LRU cache for sprite textures
+- **Background loading**: Load previews in goroutine
+- **Debounced search**: 100ms delay before filtering
+
+#### Memory
+- **Stream large files**: Don't load entire file for preview
+- **Unload hidden textures**: Free textures not in view
+- **Limit preview size**: Max 2048x2048 for images
+
+#### Cross-Platform
+- cimgui-go provides pre-built binaries for:
+  - Windows (x64)
+  - macOS (x64, arm64)
+  - Linux (x64)
+
+## Consequences
+
+### Positive
+- Comprehensive asset browser for development
+- Validates all file format parsers
+- Foundation for modding tools
+- Professional UX inspired by game engines
+
+### Negative
+- Adds cimgui-go dependency (CGO required)
+- More complex than simple CLI tool
+- Longer development time
+
+### Mitigations
+- Stage-based development allows early usable versions
+- ImGui reduces UI boilerplate significantly
+- Existing window/renderer code reusable
+
+## References
+
+- [Dear ImGui](https://github.com/ocornut/imgui)
+- [cimgui-go](https://github.com/AllenDang/cimgui-go) - Go bindings
+- [ImGui Demo](https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp) - UI patterns
+- [Unity Project Window](https://docs.unity3d.com/Manual/ProjectView.html)
+- [GRF Format - ADR-006](./ADR-006-grf-archive-reader.md)
+- [SPR Format - ADR-007](./ADR-007-spr-format-parser.md)
+- [ACT Format - ADR-008](./ADR-008-act-format-parser.md)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/Faultbox/midgard-ro
 
-go 1.22
+go 1.24.0
+
+toolchain go1.24.11
 
 require (
 	github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71
@@ -10,4 +12,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require go.uber.org/multierr v1.10.0 // indirect
+require (
+	github.com/AllenDang/cimgui-go v1.4.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/AllenDang/cimgui-go v1.4.0 h1:jrgAIysC7ToTaoFSL3wxsZUV9NOQyiTQ5cX3u27mANA=
+github.com/AllenDang/cimgui-go v1.4.0/go.mod h1:VCrH8Wyb3pZ2cYQM630LmdquB1OkeXMnmBv/oTDQn1c=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 h1:5BVwOaUSBTlVZowGO6VZGw2H/zl9nrd3eCZfYV+NfQA=
@@ -14,6 +16,8 @@ go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
 go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
+golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=


### PR DESCRIPTION
## Summary
- Add Dear ImGui-based graphical tool for browsing GRF archives
- Implements ADR-009 Stage 1: Foundation with navigation, search, and filters
- Uses cimgui-go with SDL2 backend, integrates with existing pkg/grf package

## Features
- Two-panel layout: Files tree (left) and Preview panel (right)
- File tree with virtual folder structure built from GRF file paths
- Live search filtering by filename
- Type filter checkboxes: Sprites, Animations, Textures, Models, Maps, Audio, Other
- Text-based file type icons: `[SPR]`, `[IMG]`, `[MAP]`, `[GAT]`, `[GND]`, `[TXT]`
- Status bar showing total/filtered file counts
- Keyboard shortcuts:
  - `Ctrl+C` - copy filename
  - `Cmd+Ctrl+C` - copy full path (macOS friendly)
- EUC-KR to UTF-8 filename conversion for Korean file names

## Usage
```bash
make build-tools
./build/grfbrowser -grf path/to/archive.grf
```

## Known Limitations (Stage 2+)
- Korean font glyphs not rendered (requires loading custom font)
- File > Open GRF menu not implemented (use -grf flag)
- File preview not implemented (Stage 3)

## Test plan
- [x] Build with `make build-tools`
- [x] Launch with real GRF file
- [x] Verify file tree displays correctly
- [x] Test search filtering
- [x] Test type filter toggles
- [x] Test Ctrl+C and Cmd+Ctrl+C copy shortcuts
- [x] Verify status bar updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)