### PR TITLE
feat(grfbrowser): implement sprite viewer (ADR-009 Stage 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 build/
 bin/
+grfbrowser
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/grfbrowser/main.go
+++ b/cmd/grfbrowser/main.go
@@ -1416,20 +1416,20 @@ func (app *App) renderActionsPanel() {
 func getActionName(index int) string {
 	// Standard RO action indices (may vary by sprite type)
 	names := []string{
-		"Idle",           // 0
-		"Walk",           // 1
-		"Sit",            // 2
-		"Pick Up",        // 3
-		"Standby",        // 4
-		"Attack 1",       // 5
-		"Damage",         // 6
-		"Die",            // 7
-		"Attack 2",       // 8
-		"Attack 3",       // 9
-		"Dead",           // 10
-		"Skill Cast",     // 11
-		"Skill Ready",    // 12
-		"Freeze",         // 13
+		"Idle",        // 0
+		"Walk",        // 1
+		"Sit",         // 2
+		"Pick Up",     // 3
+		"Standby",     // 4
+		"Attack 1",    // 5
+		"Damage",      // 6
+		"Die",         // 7
+		"Attack 2",    // 8
+		"Attack 3",    // 9
+		"Dead",        // 10
+		"Skill Cast",  // 11
+		"Skill Ready", // 12
+		"Freeze",      // 13
 	}
 
 	if index < len(names) {

--- a/pkg/formats/spr.go
+++ b/pkg/formats/spr.go
@@ -48,9 +48,10 @@ type SPRPalette struct {
 
 // SPR represents a parsed sprite file.
 type SPR struct {
-	Version SPRVersion
-	Images  []SPRImage  // All images converted to RGBA
-	Palette *SPRPalette // Original palette (nil for pure TGA sprites)
+	Version      SPRVersion
+	Images       []SPRImage  // All images converted to RGBA
+	Palette      *SPRPalette // Original palette (nil for pure TGA sprites)
+	IndexedCount int         // Number of indexed (palette) images; RGBA images start after this
 }
 
 // ParseSPR parses an SPR file from raw bytes.
@@ -95,8 +96,9 @@ func ParseSPR(data []byte) (*SPR, error) {
 	}
 
 	spr := &SPR{
-		Version: version,
-		Images:  make([]SPRImage, 0, int(indexedCount)+int(trueColorCount)),
+		Version:      version,
+		Images:       make([]SPRImage, 0, int(indexedCount)+int(trueColorCount)),
+		IndexedCount: int(indexedCount),
 	}
 
 	// Parse palette (last 1024 bytes for v1.1+)


### PR DESCRIPTION
## Summary

Implements Stage 3 of ADR-009 GRF Browser: Sprite Viewer functionality with comprehensive animation support.

### Sprite Preview
- **SPR loading**: Parse SPR files and create OpenGL textures for all frames
- **Frame display**: Single frame preview with navigation controls (< > buttons)
- **Zoom controls**: Button and keyboard (+/-/0) zoom support
- **Preview centering**: Center sprites horizontally and vertically

### Animation Preview
- **ACT loading**: Parse animation files with action/frame structure
- **Actions panel**: Dedicated right panel for ACT files with:
  - Play/Pause button with Space key shortcut
  - Frame navigation controls
  - Scrollable action list with standard RO action names (Idle, Walk, Sit, etc.)
  - Click-to-select action functionality
- **Animation timing**: Proper game tick conversion (24ms/tick) with 100ms minimum floor
- **RGBA sprite support**: Correct handling of true-color sprites (SpriteType 1)

### UX Improvements
- Auto-select files when navigating with arrow keys
- Directory nodes show selection highlight when focused
- Space key toggles directory expand/collapse
- Copy notification overlay (Ctrl+C for filename, Cmd+Ctrl+C for full path)
- Filter buttons: "All" / "None" for quick selection
- Korean search support (matches against UTF-8 display paths)

### Bug Fixes
- Korean path lookup now correctly uses original EUC-KR path for archive reads
- Case-insensitive SPR file lookup (.spr, .SPR, .Spr)
- Informative message for empty frames (garment/accessory overlays)
- Added SPR.IndexedCount field to track indexed vs RGBA image boundary
- Preview cleared when loading new GRF file

### Known Limitations (deferred to Stage 5)
- TAB key uses ImGui default behavior (navigates within tree)
- Custom panel cycling requires further ImGui ConfigFlags research
- Ctrl+Tab works for focus switching (ImGui built-in)

## Test plan
- [ ] Load GRF via File > Open GRF menu
- [ ] Navigate tree with mouse and arrow keys
- [ ] Verify directory selection highlighting
- [ ] Select .spr file and verify sprite preview
- [ ] Test frame navigation (< > buttons)
- [ ] Test zoom (+/- buttons and keyboard, 0 to reset)
- [ ] Select .act file and test animation playback
- [ ] Test Actions panel: Play/Pause, action selection, frame navigation
- [ ] Press Space to toggle Play/Pause
- [ ] Test Korean filename search
- [ ] Test Ctrl+C copy notification
- [ ] Test filter All/None buttons
- [ ] Verify Korean filenames display correctly
- [ ] Test sprites with Korean paths load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)