### PR TITLE
docs(sessions): add session log for 2026-01-11 part 2

### DIFF
--- a/docs/sessions/2026-01-11-part2.md
+++ b/docs/sessions/2026-01-11-part2.md
@@ -1,0 +1,86 @@
+# Session Log: 2026-01-11 (Part 2)
+
+## Summary
+Completed ADR-009 GRF Browser Stage 3: Sprite Viewer with comprehensive animation support and UX improvements.
+
+## What Was Accomplished
+
+### 1. Sprite Preview (SPR Files)
+- SPR file loading with OpenGL texture creation for all frames
+- Single frame display with navigation (< > buttons)
+- Zoom controls: buttons (+/-) and keyboard shortcuts (+/-/0)
+- Preview centering (horizontal and vertical)
+- Checkerboard background for transparency visualization
+
+### 2. Animation Preview (ACT Files)
+- ACT file loading with action/frame structure parsing
+- **Actions Panel**: Dedicated right-side panel for ACT files with:
+  - Play/Pause button with Space key shortcut
+  - Frame navigation controls (< >)
+  - Scrollable action list with click-to-select
+  - Standard RO action names (Idle, Walk, Sit, Pick Up, Standby, Attack, etc.)
+- Animation timing: Proper game tick conversion (24ms/tick) with 100ms minimum floor
+- RGBA sprite support: Correct handling of SpriteType 1 (true-color sprites offset by IndexedCount)
+
+### 3. Korean Path Handling
+- Fixed Korean path lookup: Use original EUC-KR path for archive reads
+- Case-insensitive SPR file lookup (.spr, .SPR, .Spr)
+- Korean search support: Match against UTF-8 display paths instead of EUC-KR
+
+### 4. UX Improvements
+- Auto-select files when navigating with arrow keys
+- Directory nodes show selection highlight when focused
+- Space key toggles directory expand/collapse in tree
+- **Copy notification**: Overlay feedback for Ctrl+C (filename) and Cmd+Ctrl+C (full path)
+- **Filter buttons**: "All" / "None" for quick filter selection
+- Informative messages for empty frames (garment/accessory overlays)
+
+### 5. Bug Fixes
+- Added SPR.IndexedCount field to track indexed vs RGBA image boundary
+- Clear preview when loading new GRF file
+- Debug output for SPR file lookup failures
+
+## Files Changed
+- `cmd/grfbrowser/main.go` - Sprite/animation preview, Actions panel, UX improvements
+- `pkg/formats/spr.go` - Added IndexedCount field for RGBA sprite handling
+- `.gitignore` - Added grfbrowser binary
+
+## PR
+- **PR #24**: feat(grfbrowser): implement sprite viewer (ADR-009 Stage 3)
+- Status: **Merged**
+- Commits: 5
+
+## QA Verification
+- Automated code review: All 14 test plan items PASS
+- CI: Build ✅ Test ✅ Lint ✅
+- Manual testing performed during development
+
+## Keyboard Shortcuts Summary
+| Shortcut | Action |
+|----------|--------|
+| Space | Toggle Play/Pause (animations) / Expand-collapse (tree) |
+| +/- | Zoom in/out |
+| 0 | Reset zoom |
+| Ctrl+C | Copy filename |
+| Cmd+Ctrl+C | Copy full path |
+| F12 | Screenshot |
+| Ctrl+D | Dump state JSON |
+
+## Stage 3 Complete Features
+- [x] SPR loading and texture creation
+- [x] Frame display with navigation
+- [x] ACT loading
+- [x] Animation playback with timing
+- [x] Zoom controls
+- [x] Actions panel with action names
+- [x] Korean path support
+- [x] UX improvements (copy notification, filter buttons, Korean search)
+
+## Known Limitations (Deferred to Stage 5)
+- TAB key uses ImGui default behavior (navigates within tree)
+- Custom panel cycling requires further ImGui ConfigFlags research
+- Ctrl+Tab works for focus switching (ImGui built-in)
+
+## Next Steps
+- Stage 4: Texture viewer (BMP/TGA/PNG preview)
+- Stage 5: Polish and keyboard navigation improvements


### PR DESCRIPTION
## Summary
- Add session log documenting Stage 3 completion of ADR-009 GRF Browser

## What Was Accomplished
- Sprite preview with frame navigation and zoom
- Animation preview with Actions panel and standard RO action names
- Korean path and search support
- UX improvements (copy notification, filter buttons)

## Test plan
- [x] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)