### PR TITLE
fix(grfbrowser): wildcard search and action name fixes

### DIFF
--- a/cmd/grfbrowser/main.go
+++ b/cmd/grfbrowser/main.go
@@ -1687,10 +1687,11 @@ func (app *App) renderActionsPanel() {
 	imgui.Text("Actions:")
 
 	// Scrollable action list
+	totalActions := len(act.Actions)
 	if imgui.BeginChildStrV("ActionList", imgui.NewVec2(0, 0), imgui.ChildFlagsBorders, 0) {
-		for i := 0; i < len(act.Actions); i++ {
+		for i := 0; i < totalActions; i++ {
 			action := act.Actions[i]
-			name := getActionName(i)
+			name := getActionName(i, totalActions)
 			label := fmt.Sprintf("%d: %s (%d)", i, name, len(action.Frames))
 
 			isSelected := i == app.previewAction
@@ -1703,29 +1704,79 @@ func (app *App) renderActionsPanel() {
 	imgui.EndChild()
 }
 
+// Direction names for 8-direction sprites (standard RO order).
+var directionNames = []string{
+	"S", "SW", "W", "NW", "N", "NE", "E", "SE",
+}
+
+// Monster action type names (typically 5-8 action types with 8 directions each).
+// Monsters have: Idle, Walk, Attack, Damage, Die (and sometimes more attacks).
+var monsterActionNames = []string{
+	"Idle",     // 0
+	"Walk",     // 1
+	"Attack",   // 2
+	"Damage",   // 3
+	"Die",      // 4
+	"Attack 2", // 5 (some monsters)
+	"Attack 3", // 6 (some monsters)
+	"Special",  // 7 (some monsters)
+}
+
+// Player action type names (typically 13+ action types with 8 directions each).
+// Players have more actions including Sit, Pick Up, Standby, multiple attacks, casting.
+var playerActionNames = []string{
+	"Idle",        // 0
+	"Walk",        // 1
+	"Sit",         // 2
+	"Pick Up",     // 3
+	"Standby",     // 4
+	"Attack 1",    // 5
+	"Damage",      // 6
+	"Die",         // 7
+	"Dead",        // 8
+	"Attack 2",    // 9
+	"Attack 3",    // 10
+	"Skill Cast",  // 11
+	"Skill Ready", // 12
+	"Freeze",      // 13
+}
+
 // getActionName returns a standard RO action name for the given index.
-func getActionName(index int) string {
-	// Standard RO action indices (may vary by sprite type)
-	names := []string{
-		"Idle",        // 0
-		"Walk",        // 1
-		"Sit",         // 2
-		"Pick Up",     // 3
-		"Standby",     // 4
-		"Attack 1",    // 5
-		"Damage",      // 6
-		"Die",         // 7
-		"Attack 2",    // 8
-		"Attack 3",    // 9
-		"Dead",        // 10
-		"Skill Cast",  // 11
-		"Skill Ready", // 12
-		"Freeze",      // 13
+// For sprites with 8 directions per action, shows "ActionType Dir" format.
+// Uses different naming based on total action count to detect monster vs player sprites.
+func getActionName(index, totalActions int) string {
+	// Check if this looks like an 8-direction sprite (multiple of 8 actions)
+	if totalActions >= 8 && totalActions%8 == 0 {
+		actionType := index / 8
+		direction := index % 8
+		dirName := directionNames[direction]
+
+		// Determine sprite type based on action count:
+		// - Monster sprites: typically 40-64 actions (5-8 action types)
+		// - Player sprites: typically 80+ actions (10+ action types)
+		var typeName string
+		actionTypeCount := totalActions / 8
+
+		if actionTypeCount <= 8 {
+			// Likely a monster sprite
+			if actionType < len(monsterActionNames) {
+				typeName = monsterActionNames[actionType]
+			} else {
+				typeName = fmt.Sprintf("Action%d", actionType)
+			}
+		} else {
+			// Likely a player sprite
+			if actionType < len(playerActionNames) {
+				typeName = playerActionNames[actionType]
+			} else {
+				typeName = fmt.Sprintf("Action%d", actionType)
+			}
+		}
+
+		return fmt.Sprintf("%s %s", typeName, dirName)
 	}
 
-	if index < len(names) {
-		return names[index]
-	}
+	// Non-8-direction sprite (items, effects, etc.) - just show index
 	return fmt.Sprintf("Action %d", index)
 }
 


### PR DESCRIPTION
## Summary
Follow-up fixes after Stage 4 merge:
- Add wildcard search support (`*.bmp`, `item_*.spr`, etc.)
- Fix action names to correctly detect monster vs player sprites

## Changes

### Wildcard Search
- Search now supports glob patterns using `filepath.Match`
- Matches against filename for patterns like `*.bmp`
- Falls back to substring search when no wildcards present

### Action Name Detection
- Monster sprites (≤64 actions): Idle, Walk, Attack, Damage, Die
- Player sprites (>64 actions): Idle, Walk, Sit, Pick Up, Standby, Attack 1, Damage, Die, Dead, Attack 2...
- Detection based on total action count (action types × 8 directions)

## Test plan
- [x] Wildcard search tested with `*.bmp`
- [x] Monster sprite actions verified
- [x] Player sprite actions verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)