### PR TITLE
docs(sessions): add session log for 2026-01-11 part 3

### DIFF
--- a/docs/sessions/2026-01-11-part3.md
+++ b/docs/sessions/2026-01-11-part3.md
@@ -1,0 +1,86 @@
+# Session Log: 2026-01-11 (Part 3)
+
+## Summary
+Completed ADR-009 GRF Browser Stage 4: Image/Text/Hex viewers, wildcard search, action name fixes, and WAV audio playback.
+
+## What Was Accomplished
+
+### 1. Image Viewer (BMP, TGA, JPG, PNG)
+- Custom TGA decoder supporting uncompressed and RLE-compressed true-color images
+- Zoom controls (+/-/Reset) with centered display
+- Support for both 24-bit and 32-bit TGA formats
+- PR #26 merged
+
+### 2. Text Viewer (.txt, .xml, .lua, .ini, .cfg)
+- Scrollable text area with Korean (EUC-KR → UTF-8) conversion
+- 64KB preview limit for performance
+- PR #26 merged
+
+### 3. Hex Viewer (fallback for unknown formats)
+- Classic hex dump format: `offset | hex bytes | ASCII`
+- 4KB preview limit
+- Automatic fallback for unrecognized file types
+- PR #26 merged
+
+### 4. Wildcard Search
+- Search now supports glob patterns: `*.bmp`, `item_*.spr`, etc.
+- Uses `filepath.Match` for pattern matching against filename
+- Falls back to substring search when no wildcards present
+- PR #27 merged
+
+### 5. Action Name Detection (Monster vs Player)
+- **Monster sprites** (≤64 actions): Idle, Walk, Attack, Damage, Die
+- **Player sprites** (>64 actions): Idle, Walk, Sit, Pick Up, Standby, Attack 1, Damage, Die, Dead, Attack 2...
+- Detection based on total action count (action types × 8 directions)
+- PR #27 merged
+
+### 6. WAV Audio Playback
+- Play/Stop button controls
+- Progress bar showing current position with time display
+- Format info: sample rate, channels, duration
+- Uses `gopxl/beep` library for audio decoding and playback
+- Auto-stop when switching files
+- PR #28 merged
+
+## Files Changed
+- `cmd/grfbrowser/main.go` - All new viewers, search, audio playback
+- `go.mod` / `go.sum` - Added golang.org/x/image/bmp, gopxl/beep dependencies
+- `.gitignore` - Fixed to use `/grfbrowser` (root only)
+
+## PRs Merged
+- **PR #26**: feat(grfbrowser): implement image, text, and hex viewers (ADR-009 Stage 4)
+- **PR #27**: fix(grfbrowser): wildcard search and action name fixes
+- **PR #28**: feat(grfbrowser): add WAV audio playback support
+
+## Stage 4 Complete Features
+- [x] BMP/TGA/JPG/PNG image viewer with zoom
+- [x] Text viewer with Korean support
+- [x] Hex viewer for unknown formats
+- [x] Wildcard search (`*.bmp`, `*.spr`)
+- [x] Correct action names for monster/player sprites
+- [x] WAV audio playback with controls
+
+## Technical Notes
+
+### TGA Decoder
+Custom implementation supporting:
+- Type 2: Uncompressed true-color
+- Type 10: RLE compressed true-color
+- 24-bit and 32-bit pixel formats
+- Top-to-bottom and bottom-to-top orientation
+
+### Audio Playback
+- Speaker initialized once on first WAV load
+- Streamer properly closed on file switch
+- Callback-based completion detection
+
+### Action Detection Heuristic
+```
+if totalActions/8 <= 8:  → Monster sprite
+else:                    → Player sprite
+```
+
+## Next Steps
+- Stage 5: Polish and keyboard navigation improvements
+- Consider MP3/OGG support if needed
+- Map viewer (RSW/GND/GAT) for future stages


### PR DESCRIPTION
## Summary
Session log documenting Stage 4 completion of ADR-009 GRF Browser.

## Accomplished
- Image viewer (BMP, TGA, JPG, PNG) with custom TGA decoder
- Text viewer with Korean support
- Hex viewer for unknown formats
- Wildcard search (`*.bmp`, `*.spr`)
- Action name detection (monster vs player sprites)
- WAV audio playback with Play/Stop and progress bar

## PRs Merged This Session
- PR #26: Image/Text/Hex viewers
- PR #27: Wildcard search + action fixes
- PR #28: WAV audio playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)