### PR TITLE
fix: Correct RSM keyframe parsing for v1.4 and v1.5

### DIFF
--- a/pkg/formats/rsm_test.go
+++ b/pkg/formats/rsm_test.go
@@ -304,10 +304,18 @@ func TestRSM_HasAnimation(t *testing.T) {
 			want:  false,
 		},
 		{
-			name: "has rotation keys",
+			name: "single keyframe is not animation",
 			nodes: []RSMNode{{
 				Name:    "node",
 				RotKeys: []RSMRotKeyframe{{Frame: 0}},
+			}},
+			want: false, // Need 2+ keyframes to animate
+		},
+		{
+			name: "has rotation keys",
+			nodes: []RSMNode{{
+				Name:    "node",
+				RotKeys: []RSMRotKeyframe{{Frame: 0}, {Frame: 100}},
 			}},
 			want: true,
 		},
@@ -315,7 +323,7 @@ func TestRSM_HasAnimation(t *testing.T) {
 			name: "has position keys",
 			nodes: []RSMNode{{
 				Name:    "node",
-				PosKeys: []RSMPosKeyframe{{Frame: 0}},
+				PosKeys: []RSMPosKeyframe{{Frame: 0}, {Frame: 100}},
 			}},
 			want: true,
 		},
@@ -323,7 +331,7 @@ func TestRSM_HasAnimation(t *testing.T) {
 			name: "has scale keys",
 			nodes: []RSMNode{{
 				Name:      "node",
-				ScaleKeys: []RSMScaleKeyframe{{Frame: 0}},
+				ScaleKeys: []RSMScaleKeyframe{{Frame: 0}, {Frame: 100}},
 			}},
 			want: true,
 		},


### PR DESCRIPTION
## Summary

- Fix RSM animation parsing that was causing corrupted node data and broken animations
- Position keyframes (posKeyCount) only exist in v < 1.4, not v < 1.5
- Scale keyframes (scaleKeyCount) only exist in v >= 2.0, not v >= 1.5
- Read rotation keyframes before position keyframes (correct order)
- HasAnimation() now requires 2+ keyframes (single keyframe is static)

## Background

During Stage 3 (3D model rendering) development, we discovered that many RSM models were displaying incorrectly or without animation. Investigation revealed that:

1. **v1.4 models were corrupted**: Parser was reading `posKeyCount` field that doesn't exist in v1.4, causing node names to become garbage
2. **v1.5 models had no animation**: Parser was reading `scaleKeyCount` field that doesn't exist in v1.5

## Test plan

- [x] All existing RSM unit tests pass
- [x] Verified v1.4 models parse correctly (adventure.rsm with 42 nodes)
- [x] Verified v1.4 animations work (clock.rsm, wheel_h_01.rsm, cafe_j_01.rsm)
- [x] Verified v1.5 animations work (smithy_06.rsm, timemachine_s_01.rsm)
- [x] Build passes
- [x] Lint passes (on changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)