### PR TITLE
feat: Add 3D model viewer for RSM files (ADR-012 Stage 3)

### DIFF
--- a/cmd/grfbrowser/main.go
+++ b/cmd/grfbrowser/main.go
@@ -94,6 +94,8 @@ type App struct {
 	previewLastTime time.Time          // Last frame update time
 	previewPath     string             // Path of currently previewed file
 	previewZoom     float32            // Zoom level for preview
+	previewSpeed    float32            // Animation playback speed (1.0 = normal)
+	previewLooping  bool               // Whether animation loops
 
 	// Image preview state (ADR-009 Stage 4)
 	previewImage   *backend.Texture // Texture for image preview
@@ -174,6 +176,8 @@ func NewApp() *App {
 		filterOther:         true,
 		screenshotDir:       "/tmp/grfbrowser",
 		previewZoom:         1.0,
+		previewSpeed:        1.0,  // Normal playback speed
+		previewLooping:      true, // Loop by default
 		magentaTransparency: true, // Enable magenta key transparency by default
 	}
 
@@ -380,6 +384,13 @@ func (app *App) render() {
 			if app.previewPlaying {
 				app.previewLastTime = time.Now()
 			}
+		}
+	}
+
+	// Space to toggle Play/Pause for RSM animations (when not in text input)
+	if app.modelViewer != nil && app.modelViewer.HasAnimation() && !imgui.IsAnyItemActive() {
+		if imgui.IsKeyChordPressed(imgui.KeyChord(imgui.KeySpace)) {
+			app.modelViewer.ToggleAnimation()
 		}
 	}
 

--- a/pkg/math/quat.go
+++ b/pkg/math/quat.go
@@ -1,0 +1,139 @@
+package math
+
+import "math"
+
+// Quat represents a quaternion for 3D rotations.
+// Components are stored as X, Y, Z, W where W is the scalar part.
+type Quat struct {
+	X, Y, Z, W float32
+}
+
+// QuatIdentity returns an identity quaternion (no rotation).
+func QuatIdentity() Quat {
+	return Quat{X: 0, Y: 0, Z: 0, W: 1}
+}
+
+// QuatFromAxisAngle creates a quaternion from axis-angle rotation.
+// axis should be normalized, angle is in radians.
+func QuatFromAxisAngle(axis Vec3, angle float32) Quat {
+	halfAngle := angle / 2
+	s := float32(math.Sin(float64(halfAngle)))
+	return Quat{
+		X: axis.X * s,
+		Y: axis.Y * s,
+		Z: axis.Z * s,
+		W: float32(math.Cos(float64(halfAngle))),
+	}
+}
+
+// Normalize returns a normalized quaternion.
+func (q Quat) Normalize() Quat {
+	length := float32(math.Sqrt(float64(q.X*q.X + q.Y*q.Y + q.Z*q.Z + q.W*q.W)))
+	if length < 0.0001 {
+		return QuatIdentity()
+	}
+	invLen := 1.0 / length
+	return Quat{
+		X: q.X * invLen,
+		Y: q.Y * invLen,
+		Z: q.Z * invLen,
+		W: q.W * invLen,
+	}
+}
+
+// Dot returns the dot product of two quaternions.
+func (q Quat) Dot(other Quat) float32 {
+	return q.X*other.X + q.Y*other.Y + q.Z*other.Z + q.W*other.W
+}
+
+// Slerp performs spherical linear interpolation between two quaternions.
+// t should be in range [0, 1].
+func (q Quat) Slerp(other Quat, t float32) Quat {
+	// Compute cos of angle between quaternions
+	dot := q.Dot(other)
+
+	// If dot is negative, negate one quaternion to take the shorter path
+	if dot < 0 {
+		other = Quat{X: -other.X, Y: -other.Y, Z: -other.Z, W: -other.W}
+		dot = -dot
+	}
+
+	// If quaternions are very close, use linear interpolation to avoid division by zero
+	if dot > 0.9995 {
+		return Quat{
+			X: q.X + t*(other.X-q.X),
+			Y: q.Y + t*(other.Y-q.Y),
+			Z: q.Z + t*(other.Z-q.Z),
+			W: q.W + t*(other.W-q.W),
+		}.Normalize()
+	}
+
+	// Standard slerp
+	theta0 := float32(math.Acos(float64(dot)))
+	theta := theta0 * t
+	sinTheta := float32(math.Sin(float64(theta)))
+	sinTheta0 := float32(math.Sin(float64(theta0)))
+
+	s0 := float32(math.Cos(float64(theta))) - dot*sinTheta/sinTheta0
+	s1 := sinTheta / sinTheta0
+
+	return Quat{
+		X: q.X*s0 + other.X*s1,
+		Y: q.Y*s0 + other.Y*s1,
+		Z: q.Z*s0 + other.Z*s1,
+		W: q.W*s0 + other.W*s1,
+	}
+}
+
+// ToMat4 converts the quaternion to a 4x4 rotation matrix.
+func (q Quat) ToMat4() Mat4 {
+	// Normalize first
+	q = q.Normalize()
+
+	xx := q.X * q.X
+	xy := q.X * q.Y
+	xz := q.X * q.Z
+	xw := q.X * q.W
+	yy := q.Y * q.Y
+	yz := q.Y * q.Z
+	yw := q.Y * q.W
+	zz := q.Z * q.Z
+	zw := q.Z * q.W
+
+	return Mat4{
+		1 - 2*(yy+zz), 2 * (xy + zw), 2 * (xz - yw), 0,
+		2 * (xy - zw), 1 - 2*(xx+zz), 2 * (yz + xw), 0,
+		2 * (xz + yw), 2 * (yz - xw), 1 - 2*(xx+yy), 0,
+		0, 0, 0, 1,
+	}
+}
+
+// Lerp performs linear interpolation between two quaternions.
+// Use Slerp for rotation interpolation; this is for simple blending.
+func (q Quat) Lerp(other Quat, t float32) Quat {
+	return Quat{
+		X: q.X + t*(other.X-q.X),
+		Y: q.Y + t*(other.Y-q.Y),
+		Z: q.Z + t*(other.Z-q.Z),
+		W: q.W + t*(other.W-q.W),
+	}.Normalize()
+}
+
+// Mul multiplies two quaternions (combines rotations).
+func (q Quat) Mul(other Quat) Quat {
+	return Quat{
+		X: q.W*other.X + q.X*other.W + q.Y*other.Z - q.Z*other.Y,
+		Y: q.W*other.Y - q.X*other.Z + q.Y*other.W + q.Z*other.X,
+		Z: q.W*other.Z + q.X*other.Y - q.Y*other.X + q.Z*other.W,
+		W: q.W*other.W - q.X*other.X - q.Y*other.Y - q.Z*other.Z,
+	}
+}
+
+// LerpVec3 performs linear interpolation between two 3D vectors.
+func LerpVec3(a, b [3]float32, t float32) [3]float32 {
+	return [3]float32{
+		a[0] + t*(b[0]-a[0]),
+		a[1] + t*(b[1]-a[1]),
+		a[2] + t*(b[2]-a[2]),
+	}
+}

--- a/pkg/math/quat_test.go
+++ b/pkg/math/quat_test.go
@@ -1,0 +1,92 @@
+package math
+
+import (
+	"math"
+	"testing"
+)
+
+func TestQuatIdentity(t *testing.T) {
+	q := QuatIdentity()
+	if q.X != 0 || q.Y != 0 || q.Z != 0 || q.W != 1 {
+		t.Errorf("Identity quaternion should be (0,0,0,1), got (%v,%v,%v,%v)", q.X, q.Y, q.Z, q.W)
+	}
+}
+
+func TestQuatNormalize(t *testing.T) {
+	q := Quat{X: 1, Y: 2, Z: 3, W: 4}
+	n := q.Normalize()
+
+	length := float32(math.Sqrt(float64(n.X*n.X + n.Y*n.Y + n.Z*n.Z + n.W*n.W)))
+	if math.Abs(float64(length-1.0)) > 0.0001 {
+		t.Errorf("Normalized quaternion length should be 1, got %v", length)
+	}
+}
+
+func TestQuatSlerp(t *testing.T) {
+	// Test endpoints
+	q1 := QuatIdentity()
+	q2 := QuatFromAxisAngle(Vec3{X: 0, Y: 1, Z: 0}, float32(math.Pi/2))
+
+	// At t=0, should equal q1
+	result0 := q1.Slerp(q2, 0)
+	if math.Abs(float64(result0.W-q1.W)) > 0.001 {
+		t.Errorf("Slerp at t=0 should equal q1")
+	}
+
+	// At t=1, should equal q2
+	result1 := q1.Slerp(q2, 1)
+	if math.Abs(float64(result1.W-q2.W)) > 0.001 {
+		t.Errorf("Slerp at t=1 should equal q2")
+	}
+
+	// At t=0.5, should be halfway
+	result5 := q1.Slerp(q2, 0.5)
+	// For 90 degree rotation, halfway should be 45 degrees
+	expectedW := float32(math.Cos(float64(math.Pi / 8))) // cos(45/2 degrees)
+	if math.Abs(float64(result5.W-expectedW)) > 0.01 {
+		t.Errorf("Slerp at t=0.5: expected W ~%v, got %v", expectedW, result5.W)
+	}
+}
+
+func TestQuatToMat4(t *testing.T) {
+	// Identity quaternion should produce identity matrix
+	q := QuatIdentity()
+	m := q.ToMat4()
+
+	identity := Identity()
+	for i := 0; i < 16; i++ {
+		if math.Abs(float64(m[i]-identity[i])) > 0.0001 {
+			t.Errorf("Identity quat should produce identity matrix, element %d: got %v, want %v", i, m[i], identity[i])
+		}
+	}
+}
+
+func TestQuatFromAxisAngle(t *testing.T) {
+	// 90 degrees around Y axis
+	q := QuatFromAxisAngle(Vec3{X: 0, Y: 1, Z: 0}, float32(math.Pi/2))
+
+	// Should have Y component and W = cos(45deg)
+	expectedW := float32(math.Cos(math.Pi / 4))
+	expectedY := float32(math.Sin(math.Pi / 4))
+
+	if math.Abs(float64(q.W-expectedW)) > 0.001 {
+		t.Errorf("QuatFromAxisAngle W: expected %v, got %v", expectedW, q.W)
+	}
+	if math.Abs(float64(q.Y-expectedY)) > 0.001 {
+		t.Errorf("QuatFromAxisAngle Y: expected %v, got %v", expectedY, q.Y)
+	}
+}
+
+func TestLerpVec3(t *testing.T) {
+	a := [3]float32{0, 0, 0}
+	b := [3]float32{10, 20, 30}
+
+	result := LerpVec3(a, b, 0.5)
+	expected := [3]float32{5, 10, 15}
+
+	for i := 0; i < 3; i++ {
+		if math.Abs(float64(result[i]-expected[i])) > 0.001 {
+			t.Errorf("LerpVec3 component %d: expected %v, got %v", i, expected[i], result[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implement full 3D rendering of RSM models in GRF Browser
- Add interactive camera controls (orbit, zoom)
- Add animation playback with timeline and speed controls
- Add quaternion math library for keyframe interpolation

## Features

### 3D Model Viewer
- Offscreen framebuffer rendering (512x512)
- GLSL shaders with diffuse lighting
- Multi-texture support per model
- Magenta transparency option (RGB 255,0,255 → transparent)
- Fallback white texture for missing textures

### Camera Controls
- Mouse drag to rotate (orbit around model center)
- Mouse scroll to zoom in/out
- Reset View button to restore default camera
- Auto-fit camera to model bounding box

### Animation Playback
- Play/Pause/Stop buttons
- Timeline slider for scrubbing
- Speed control (0.1x to 3.0x)
- Loop toggle
- Space key shortcut for play/pause
- Keyframe interpolation (rotation, position, scale)

## New Files

| File | Purpose |
|------|---------|
| `cmd/grfbrowser/model_viewer.go` | 3D rendering implementation |
| `pkg/math/quat.go` | Quaternion math for animations |
| `pkg/math/quat_test.go` | Quaternion unit tests |

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Lint passes (changed files)
- [x] Manually tested with multiple RSM models:
  - Static models render correctly with textures
  - Animated models (clock, smithy_06, wheel) play animations
  - Camera controls work smoothly
  - Animation timeline and speed controls work

🤖 Generated with [Claude Code](https://claude.com/claude-code)