### PR TITLE
fix: Correct RSM node transform order for static vs animated nodes

### DIFF
--- a/cmd/grfbrowser/map_viewer.go
+++ b/cmd/grfbrowser/map_viewer.go
@@ -1274,7 +1274,7 @@ func (m *MapModel) GetNodes() []NodeDebugInfo {
 	return m.nodes
 }
 
-// GetWorldPosition returns the world position of the model.
+// GetModelWorldPosition returns the world position of the model.
 func (mv *MapViewer) GetModelWorldPosition(idx int) (float32, float32, float32) {
 	model := mv.GetModel(idx)
 	if model == nil {
@@ -2250,8 +2250,11 @@ func (mv *MapViewer) fitCamera() {
 		maxSize = sizeZ
 	}
 
-	// Default zoom distance
-	mv.Distance = 200
+	// Default zoom distance (proportional to map size)
+	mv.Distance = maxSize * 0.3
+	if mv.Distance < 200 {
+		mv.Distance = 200
+	}
 
 	mv.rotationX = 0.6 // Look down at ~35 degrees
 	mv.rotationY = 0.0

--- a/cmd/grfbrowser/preview_map.go
+++ b/cmd/grfbrowser/preview_map.go
@@ -789,6 +789,19 @@ func (app *App) renderMapControlsPanel() {
 		app.initMap3DView()
 	}
 
+	// Debug: Force all two-sided
+	forceTwo := app.mapViewer.ForceAllTwoSided
+	if imgui.Checkbox("Force Two-Sided", &forceTwo) {
+		app.mapViewer.ForceAllTwoSided = forceTwo
+		// Need to reload to apply
+		app.initMap3DView()
+	}
+	imgui.SameLineV(0, 5)
+	imgui.TextDisabled("(?)")
+	if imgui.IsItemHovered() {
+		imgui.SetTooltip("Render all faces from both sides (reloads map)")
+	}
+
 	imgui.Spacing()
 	imgui.Spacing()
 

--- a/docs/adr/ADR-014-rsm-transform-order.md
+++ b/docs/adr/ADR-014-rsm-transform-order.md
@@ -1,0 +1,162 @@
+# ADR-014: RSM Model Transform Order and Map Rendering
+
+## Status
+Accepted
+
+## Context
+
+During implementation of the 3D map viewer (ADR-013), we encountered significant issues with RSM (Ragnarok Online Model) rendering:
+1. Buildings appearing underground or floating
+2. Models with "sweep" artifacts (geometry stretched incorrectly)
+3. Floating decorative elements
+4. Animated models rendering differently from static ones
+
+This ADR documents the correct transform order discovered through investigation of the korangar reference implementation and extensive debugging.
+
+## Decision
+
+### RSM Node Transform Order
+
+RSM models have two distinct transform pipelines depending on whether the node has animation keyframes:
+
+#### Static Nodes (No Animation Keyframes)
+
+For nodes without `RotKeys`, `PosKeys`, or `ScaleKeys`, use the **korangar-style** transform:
+
+```go
+// Main transform: Offset + Rotation Matrix
+main := Translate(node.Offset[0], node.Offset[1], node.Offset[2])
+main = main.Mul(FromMat3x3(node.Matrix))
+
+// Instance transform: Position + AxisAngle + Scale
+transform := Translate(node.Position[0], node.Position[1], node.Position[2])
+if node.RotAngle != 0 {
+    transform = transform.Mul(RotateAxis(node.RotAxis, node.RotAngle))
+}
+transform = transform.Mul(Scale(node.Scale[0], node.Scale[1], node.Scale[2]))
+
+// Final: transform * main
+result = transform.Mul(main)
+```
+
+Key points:
+- `Offset` is applied as **positive** translation (not negated)
+- The 3x3 `Matrix` contains the node's base rotation
+- `RotAngle`/`RotAxis` provide additional axis-angle rotation
+- Order: Position → AxisAngle → Scale → Offset → Matrix
+
+#### Animated Nodes (Has Keyframes)
+
+For nodes with `RotKeys`, `PosKeys`, or `ScaleKeys`, use a **simpler direct order**:
+
+```go
+result := Identity()
+
+// 1. Apply scale (from keyframe or default)
+scale := node.Scale
+if len(node.ScaleKeys) > 0 {
+    scale = node.ScaleKeys[0].Scale  // Or interpolated value
+}
+result = result.Mul(Scale(scale[0], scale[1], scale[2]))
+
+// 2. Apply rotation (from keyframe quaternion or matrix)
+if len(node.RotKeys) > 0 {
+    quat := node.RotKeys[0].Quaternion  // Or interpolated
+    result = result.Mul(QuatToMat4(quat))
+} else {
+    result = result.Mul(FromMat3x3(node.Matrix))
+}
+
+// 3. Apply position (from keyframe or default)
+position := node.Position
+if len(node.PosKeys) > 0 {
+    position = node.PosKeys[0].Position  // Or interpolated
+}
+result = result.Mul(Translate(position[0], position[1], position[2]))
+```
+
+Key points:
+- Order: Scale → Rotation → Position
+- Rotation keyframes use **quaternions** (XYZW format)
+- The node's `Offset` and `Matrix` are **not used** when keyframes exist
+- This matches how RO animates models at runtime
+
+### Parent Chain
+
+Both static and animated nodes multiply by their parent's transform:
+
+```go
+if node.Parent != "" && node.Parent != node.Name {
+    parentNode := rsm.GetNodeByName(node.Parent)
+    if parentNode != nil {
+        parentMatrix := buildNodeMatrixRecursive(parentNode, rsm, visited)
+        result = parentMatrix.Mul(result)
+    }
+}
+```
+
+Use a `visited` map to prevent infinite recursion from malformed data.
+
+### Model Centering for Map Placement
+
+When placing RSM models on maps:
+- **Center X and Z** to align model origin with RSW position
+- **Do NOT center Y** - preserve vertical offset from RSM data
+
+```go
+centerX := (minX + maxX) / 2
+centerZ := (minZ + maxZ) / 2
+for i := range vertices {
+    vertices[i].Position[0] -= centerX
+    // Y is NOT centered - preserves original vertical placement
+    vertices[i].Position[2] -= centerZ
+}
+```
+
+Centering Y causes issues with models that have intentional vertical offsets (decorative elements, elevated platforms).
+
+### RSW Instance Transform
+
+After RSM model transform, apply RSW instance transform:
+
+```go
+// RSW provides position, rotation (degrees), scale
+instanceMatrix := Identity()
+instanceMatrix = instanceMatrix.Mul(Translate(rsw.Position[0], rsw.Position[1], rsw.Position[2]))
+instanceMatrix = instanceMatrix.Mul(RotateZ(DegreesToRadians(rsw.Rotation[2])))
+instanceMatrix = instanceMatrix.Mul(RotateX(DegreesToRadians(rsw.Rotation[0])))
+instanceMatrix = instanceMatrix.Mul(RotateY(DegreesToRadians(rsw.Rotation[1])))
+instanceMatrix = instanceMatrix.Mul(Scale(rsw.Scale[0], rsw.Scale[1], rsw.Scale[2]))
+```
+
+## Consequences
+
+### Positive
+- Models render correctly in their intended positions
+- Animated models (windmills, flags) work properly
+- Decorative elements maintain correct vertical placement
+- Consistent with korangar reference implementation
+
+### Negative
+- Two code paths for static vs animated nodes adds complexity
+- Must detect animation presence before choosing transform path
+
+## Debug Information
+
+The Properties panel shows useful debug info for each model:
+- RSM version, node count
+- Per-node: Offset, Position, Scale, Matrix, RotAngle/RotAxis
+- Animation flags: HasRotKeys, HasPosKeys, HasScaleKeys
+- First rotation quaternion for animated nodes
+
+## References
+
+- korangar RSM implementation: https://github.com/korangar/korangar
+- roBrowser RSM loader: https://github.com/nicklaus/roBrowser
+- RO file format documentation: Various community resources
+
+## Revision History
+
+| Date | Change |
+|------|--------|
+| 2026-01-15 | Initial version based on debugging session |

--- a/pkg/math/mat4.go
+++ b/pkg/math/mat4.go
@@ -192,3 +192,57 @@ func FromMat3x3(m3 [9]float32) Mat4 {
 func (m *Mat4) Ptr() *float32 {
 	return &m[0]
 }
+
+// Vec4 is a 4-component vector.
+type Vec4 [4]float32
+
+// MulVec4 multiplies the matrix by a Vec4.
+func (m Mat4) MulVec4(v Vec4) Vec4 {
+	return Vec4{
+		m[0]*v[0] + m[4]*v[1] + m[8]*v[2] + m[12]*v[3],
+		m[1]*v[0] + m[5]*v[1] + m[9]*v[2] + m[13]*v[3],
+		m[2]*v[0] + m[6]*v[1] + m[10]*v[2] + m[14]*v[3],
+		m[3]*v[0] + m[7]*v[1] + m[11]*v[2] + m[15]*v[3],
+	}
+}
+
+// Inverse returns the inverse of the matrix.
+// Returns identity if the matrix is singular.
+func (m Mat4) Inverse() Mat4 {
+	// Calculate cofactors
+	c00 := m[5]*m[10]*m[15] - m[5]*m[11]*m[14] - m[9]*m[6]*m[15] + m[9]*m[7]*m[14] + m[13]*m[6]*m[11] - m[13]*m[7]*m[10]
+	c01 := -m[1]*m[10]*m[15] + m[1]*m[11]*m[14] + m[9]*m[2]*m[15] - m[9]*m[3]*m[14] - m[13]*m[2]*m[11] + m[13]*m[3]*m[10]
+	c02 := m[1]*m[6]*m[15] - m[1]*m[7]*m[14] - m[5]*m[2]*m[15] + m[5]*m[3]*m[14] + m[13]*m[2]*m[7] - m[13]*m[3]*m[6]
+	c03 := -m[1]*m[6]*m[11] + m[1]*m[7]*m[10] + m[5]*m[2]*m[11] - m[5]*m[3]*m[10] - m[9]*m[2]*m[7] + m[9]*m[3]*m[6]
+
+	c10 := -m[4]*m[10]*m[15] + m[4]*m[11]*m[14] + m[8]*m[6]*m[15] - m[8]*m[7]*m[14] - m[12]*m[6]*m[11] + m[12]*m[7]*m[10]
+	c11 := m[0]*m[10]*m[15] - m[0]*m[11]*m[14] - m[8]*m[2]*m[15] + m[8]*m[3]*m[14] + m[12]*m[2]*m[11] - m[12]*m[3]*m[10]
+	c12 := -m[0]*m[6]*m[15] + m[0]*m[7]*m[14] + m[4]*m[2]*m[15] - m[4]*m[3]*m[14] - m[12]*m[2]*m[7] + m[12]*m[3]*m[6]
+	c13 := m[0]*m[6]*m[11] - m[0]*m[7]*m[10] - m[4]*m[2]*m[11] + m[4]*m[3]*m[10] + m[8]*m[2]*m[7] - m[8]*m[3]*m[6]
+
+	c20 := m[4]*m[9]*m[15] - m[4]*m[11]*m[13] - m[8]*m[5]*m[15] + m[8]*m[7]*m[13] + m[12]*m[5]*m[11] - m[12]*m[7]*m[9]
+	c21 := -m[0]*m[9]*m[15] + m[0]*m[11]*m[13] + m[8]*m[1]*m[15] - m[8]*m[3]*m[13] - m[12]*m[1]*m[11] + m[12]*m[3]*m[9]
+	c22 := m[0]*m[5]*m[15] - m[0]*m[7]*m[13] - m[4]*m[1]*m[15] + m[4]*m[3]*m[13] + m[12]*m[1]*m[7] - m[12]*m[3]*m[5]
+	c23 := -m[0]*m[5]*m[11] + m[0]*m[7]*m[9] + m[4]*m[1]*m[11] - m[4]*m[3]*m[9] - m[8]*m[1]*m[7] + m[8]*m[3]*m[5]
+
+	c30 := -m[4]*m[9]*m[14] + m[4]*m[10]*m[13] + m[8]*m[5]*m[14] - m[8]*m[6]*m[13] - m[12]*m[5]*m[10] + m[12]*m[6]*m[9]
+	c31 := m[0]*m[9]*m[14] - m[0]*m[10]*m[13] - m[8]*m[1]*m[14] + m[8]*m[2]*m[13] + m[12]*m[1]*m[10] - m[12]*m[2]*m[9]
+	c32 := -m[0]*m[5]*m[14] + m[0]*m[6]*m[13] + m[4]*m[1]*m[14] - m[4]*m[2]*m[13] - m[12]*m[1]*m[6] + m[12]*m[2]*m[5]
+	c33 := m[0]*m[5]*m[10] - m[0]*m[6]*m[9] - m[4]*m[1]*m[10] + m[4]*m[2]*m[9] + m[8]*m[1]*m[6] - m[8]*m[2]*m[5]
+
+	// Calculate determinant
+	det := m[0]*c00 + m[4]*c01 + m[8]*c02 + m[12]*c03
+
+	if det == 0 {
+		return Identity()
+	}
+
+	invDet := 1.0 / det
+
+	return Mat4{
+		c00 * invDet, c01 * invDet, c02 * invDet, c03 * invDet,
+		c10 * invDet, c11 * invDet, c12 * invDet, c13 * invDet,
+		c20 * invDet, c21 * invDet, c22 * invDet, c23 * invDet,
+		c30 * invDet, c31 * invDet, c32 * invDet, c33 * invDet,
+	}
+}


### PR DESCRIPTION
## Summary
- Fix RSM model transform order to correctly render both static and animated nodes
- Resolve issues with buildings appearing underground, animated models with keyframes, and floating decorative elements
- Add comprehensive debug tooling in Properties panel for future model investigations
- Document findings in ADR-014 for future reference

## Changes
1. **Transform Order Fix**: Split logic for static vs animated nodes
   - Static nodes: korangar-style (Offset+Matrix then Position+AxisAngle+Scale)
   - Animated nodes: simpler Scale->Rotation->Position order

2. **Centering Fix**: Center X/Z only, preserve Y offset

3. **Debug Tools**:
   - Properties panel shows RSM version, node details, animation flags
   - "Copy" and "Viewer" buttons to inspect models quickly
   - ForceAllTwoSided debug option

4. **Documentation**: ADR-014 explains correct transform order

## Test plan
- [x] Load prontera map - verify buildings render correctly
- [x] Check animated models (windmills, flags) work properly
- [x] Verify decorative elements maintain correct vertical position
- [x] Test Properties panel Copy/Viewer buttons
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)