### PR TITLE
chore: fix pre-existing lint and test failures from PR #47

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"e9bd543f-e901-4717-ac2c-db1a9bc36ea1","pid":43596,"procStart":"Fri Apr 24 16:13:30 2026","acquiredAt":1777094513492}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"e9bd543f-e901-4717-ac2c-db1a9bc36ea1","pid":43596,"procStart":"Fri Apr 24 16:13:30 2026","acquiredAt":1777094513492}

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ Desktop.ini
 # ImGui
 imgui.ini
 grftool
+
+# Claude Code runtime files (keep .claude/agents/ tracked)
+.claude/scheduled_tasks.lock
+.claude/settings.local.json

--- a/cmd/client-unified/main.go
+++ b/cmd/client-unified/main.go
@@ -69,11 +69,11 @@ func main() {
 	defer sdl.Quit()
 
 	// Set OpenGL attributes
-	sdl.GLSetAttribute(sdl.GL_CONTEXT_MAJOR_VERSION, 4)
-	sdl.GLSetAttribute(sdl.GL_CONTEXT_MINOR_VERSION, 1)
-	sdl.GLSetAttribute(sdl.GL_CONTEXT_PROFILE_MASK, sdl.GL_CONTEXT_PROFILE_CORE)
-	sdl.GLSetAttribute(sdl.GL_DOUBLEBUFFER, 1)
-	sdl.GLSetAttribute(sdl.GL_DEPTH_SIZE, 24)
+	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_MAJOR_VERSION, 4)
+	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_MINOR_VERSION, 1)
+	_ = sdl.GLSetAttribute(sdl.GL_CONTEXT_PROFILE_MASK, sdl.GL_CONTEXT_PROFILE_CORE)
+	_ = sdl.GLSetAttribute(sdl.GL_DOUBLEBUFFER, 1)
+	_ = sdl.GLSetAttribute(sdl.GL_DEPTH_SIZE, 24)
 
 	// Create window with HiDPI support
 	window, err := sdl.CreateWindow(
@@ -86,7 +86,7 @@ func main() {
 		logger.Error("Window creation failed", zap.Error(err))
 		os.Exit(1)
 	}
-	defer window.Destroy()
+	defer func() { _ = window.Destroy() }()
 
 	// Create OpenGL context
 	glContext, err := window.GLCreateContext()
@@ -110,7 +110,7 @@ func main() {
 	)
 
 	// Enable VSync
-	sdl.GLSetSwapInterval(1)
+	_ = sdl.GLSetSwapInterval(1)
 
 	// Set initial viewport using actual drawable size (for HiDPI/Retina displays)
 	drawableW, drawableH := window.GLGetDrawableSize()

--- a/internal/engine/audio/audio.go
+++ b/internal/engine/audio/audio.go
@@ -240,7 +240,7 @@ func (m *Manager) PlayBGM(data []byte, path string, loop bool) error {
 	if loop {
 		// For looping, we need a seekable streamer
 		finalStreamer = &loopStreamer{
-			streamer: streamer,
+			streamer:  streamer,
 			resampled: resampled,
 			loop:      true,
 		}

--- a/internal/engine/audio/audio_test.go
+++ b/internal/engine/audio/audio_test.go
@@ -11,10 +11,10 @@ func TestVolumeConversion(t *testing.T) {
 		min float64
 		max float64
 	}{
-		{1.0, -1, 1},      // Full volume should be ~0dB
-		{0.5, -8, -4},     // Half volume should be around -6dB
-		{0.25, -14, -10},  // Quarter volume should be around -12dB
-		{0.0, -200, -90},  // Zero volume should be very negative
+		{1.0, -1, 1},     // Full volume should be ~0dB
+		{0.5, -8, -4},    // Half volume should be around -6dB
+		{0.25, -14, -10}, // Quarter volume should be around -12dB
+		{0.0, -200, -90}, // Zero volume should be very negative
 	}
 
 	for _, tt := range tests {

--- a/internal/engine/scene/model_renderer.go
+++ b/internal/engine/scene/model_renderer.go
@@ -41,18 +41,18 @@ type ModelRenderer struct {
 	program uint32
 
 	// Uniform locations
-	locMVP           int32
-	locModel         int32
-	locLightDir      int32
-	locAmbient       int32
-	locDiffuse       int32
-	locTexture       int32
-	locFogUse        int32
-	locFogNear       int32
-	locFogFar        int32
-	locFogColor      int32
-	locLightViewProj int32
-	locShadowMap     int32
+	locMVP            int32
+	locModel          int32
+	locLightDir       int32
+	locAmbient        int32
+	locDiffuse        int32
+	locTexture        int32
+	locFogUse         int32
+	locFogNear        int32
+	locFogFar         int32
+	locFogColor       int32
+	locLightViewProj  int32
+	locShadowMap      int32
 	locShadowsEnabled int32
 
 	// Point light uniforms

--- a/internal/engine/scene/scene.go
+++ b/internal/engine/scene/scene.go
@@ -31,12 +31,12 @@ type PointLight struct {
 
 // Config contains scene configuration options.
 type Config struct {
-	Width            int32
-	Height           int32
-	ShadowResolution int32
-	ShadowsEnabled   bool
+	Width              int32
+	Height             int32
+	ShadowResolution   int32
+	ShadowsEnabled     bool
 	PointLightsEnabled bool
-	FogEnabled       bool
+	FogEnabled         bool
 }
 
 // DefaultConfig returns a default scene configuration.
@@ -66,8 +66,8 @@ type Scene struct {
 	spriteRenderer  *SpriteRenderer
 
 	// Shadow mapping
-	shadowMap     *shadow.Map
-	shadowProgram uint32
+	shadowMap              *shadow.Map
+	shadowProgram          uint32
 	locShadowLightViewProj int32
 	locShadowModel         int32
 
@@ -90,8 +90,8 @@ type Scene struct {
 	FogColor   [3]float32
 
 	// Shadows
-	ShadowsEnabled   bool
-	lightViewProj    math.Mat4
+	ShadowsEnabled bool
+	lightViewProj  math.Mat4
 
 	// Map bounds
 	MinBounds [3]float32
@@ -125,10 +125,10 @@ func New(cfg Config) (*Scene, error) {
 		LightOpacity: 1.0,
 		Brightness:   1.0,
 		// Shadow/light settings
-		ShadowsEnabled:     cfg.ShadowsEnabled,
-		PointLightsEnabled: cfg.PointLightsEnabled,
+		ShadowsEnabled:      cfg.ShadowsEnabled,
+		PointLightsEnabled:  cfg.PointLightsEnabled,
 		PointLightIntensity: 1.0,
-		FogEnabled:         cfg.FogEnabled,
+		FogEnabled:          cfg.FogEnabled,
 	}
 
 	// Create framebuffer

--- a/internal/engine/scene/sprite_renderer.go
+++ b/internal/engine/scene/sprite_renderer.go
@@ -18,13 +18,13 @@ type SpriteRenderer struct {
 	program uint32
 
 	// Uniform locations
-	locViewProj  int32
-	locWorldPos  int32
+	locViewProj   int32
+	locWorldPos   int32
 	locSpriteSize int32
-	locCamRight  int32
-	locCamUp     int32
-	locTexture   int32
-	locTint      int32
+	locCamRight   int32
+	locCamUp      int32
+	locTexture    int32
+	locTint       int32
 
 	// Billboard quad mesh
 	vao uint32
@@ -62,10 +62,10 @@ func (sr *SpriteRenderer) createQuad() {
 	vertices := []float32{
 		// Position (XY), TexCoord (UV)
 		-0.5, 0.0, 0.0, 1.0, // Bottom-left
-		0.5, 0.0, 1.0, 1.0,  // Bottom-right
-		0.5, 1.0, 1.0, 0.0,  // Top-right
+		0.5, 0.0, 1.0, 1.0, // Bottom-right
+		0.5, 1.0, 1.0, 0.0, // Top-right
 		-0.5, 0.0, 0.0, 1.0, // Bottom-left
-		0.5, 1.0, 1.0, 0.0,  // Top-right
+		0.5, 1.0, 1.0, 0.0, // Top-right
 		-0.5, 1.0, 0.0, 0.0, // Top-left
 	}
 

--- a/internal/engine/scene/water_renderer.go
+++ b/internal/engine/scene/water_renderer.go
@@ -22,10 +22,10 @@ type WaterRenderer struct {
 	program uint32
 
 	// Uniform locations
-	locMVP       int32
+	locMVP        int32
 	locWaterColor int32
-	locTime      int32
-	locWaterTex  int32
+	locTime       int32
+	locWaterTex   int32
 	locUseTexture int32
 
 	// Mesh
@@ -33,12 +33,12 @@ type WaterRenderer struct {
 	vbo uint32
 
 	// Water properties
-	waterLevel    float32
-	hasWater      bool
-	waterTime     float32
-	waterTextures []uint32
-	waterFrame    int
-	useWaterTex   bool
+	waterLevel     float32
+	hasWater       bool
+	waterTime      float32
+	waterTextures  []uint32
+	waterFrame     int
+	useWaterTex    bool
 	waterAnimSpeed float32
 }
 

--- a/internal/engine/ui/imgui.go
+++ b/internal/engine/ui/imgui.go
@@ -18,7 +18,7 @@ var koreanGlyphRanges = []imgui.Wchar{
 	0x3000, 0x30FF, // CJK Symbols and Punctuation, Hiragana, Katakana
 	0x3130, 0x318F, // Hangul Compatibility Jamo
 	0xAC00, 0xD7AF, // Hangul Syllables
-	0,              // Terminator
+	0, // Terminator
 }
 
 // Backend wraps the ImGui SDL backend for game use.

--- a/internal/engine/ui2d/context.go
+++ b/internal/engine/ui2d/context.go
@@ -39,7 +39,7 @@ type WindowState struct {
 	Skin   *NineSlice // Per-window skin override (nil uses default)
 }
 
-// New creates a new UI context.
+// NewContext creates a new UI context.
 func NewContext(width, height int) (*Context, error) {
 	r, err := New(width, height)
 	if err != nil {

--- a/internal/engine/ui2d/input.go
+++ b/internal/engine/ui2d/input.go
@@ -35,25 +35,25 @@ type InputState struct {
 	TextInput string
 
 	// Key state
-	KeyBackspace  bool
-	KeyDelete     bool
-	KeyEnter      bool
-	KeyTab        bool
-	KeyEscape     bool
-	KeyLeft       bool
-	KeyRight      bool
-	KeyUp         bool
-	KeyDown       bool
-	KeyHome       bool
-	KeyEnd        bool
-	KeyCtrl       bool
-	KeyShift      bool
-	KeyAlt        bool
-	KeySelectAll  bool // Ctrl+A
-	KeyCopy       bool // Ctrl+C
-	KeyPaste      bool // Ctrl+V
-	KeyCut        bool // Ctrl+X
-	KeyUndo       bool // Ctrl+Z
+	KeyBackspace bool
+	KeyDelete    bool
+	KeyEnter     bool
+	KeyTab       bool
+	KeyEscape    bool
+	KeyLeft      bool
+	KeyRight     bool
+	KeyUp        bool
+	KeyDown      bool
+	KeyHome      bool
+	KeyEnd       bool
+	KeyCtrl      bool
+	KeyShift     bool
+	KeyAlt       bool
+	KeySelectAll bool // Ctrl+A
+	KeyCopy      bool // Ctrl+C
+	KeyPaste     bool // Ctrl+V
+	KeyCut       bool // Ctrl+X
+	KeyUndo      bool // Ctrl+Z
 
 	// Previous frame state for edge detection
 	prevMouseLeft   bool

--- a/internal/engine/ui2d/nineslice_test.go
+++ b/internal/engine/ui2d/nineslice_test.go
@@ -50,9 +50,9 @@ func TestNineSlice_AsymmetricBorders(t *testing.T) {
 	tw := float32(ns.TexWidth)
 	th := float32(ns.TexHeight)
 
-	uL := float32(ns.Left) / tw   // 10/100 = 0.1
-	uR := (tw - float32(ns.Right)) / tw // 80/100 = 0.8
-	vT := float32(ns.Top) / th    // 5/50 = 0.1
+	uL := float32(ns.Left) / tw          // 10/100 = 0.1
+	uR := (tw - float32(ns.Right)) / tw  // 80/100 = 0.8
+	vT := float32(ns.Top) / th           // 5/50 = 0.1
 	vB := (th - float32(ns.Bottom)) / th // 35/50 = 0.7
 
 	const epsilon = 0.0001

--- a/internal/engine/ui2d/renderer.go
+++ b/internal/engine/ui2d/renderer.go
@@ -12,9 +12,9 @@ import (
 
 // imageDrawCall represents a batched image draw call.
 type imageDrawCall struct {
-	textureID  uint32
-	vertStart  int
-	vertCount  int
+	textureID uint32
+	vertStart int
+	vertCount int
 }
 
 // Renderer handles 2D UI rendering with OpenGL.

--- a/internal/game/entity/entity.go
+++ b/internal/game/entity/entity.go
@@ -41,25 +41,25 @@ type Entity struct {
 	State     State
 
 	// Visual
-	SpriteID    int    // Base sprite ID (job ID for players, monster ID for mobs)
-	HeadSprite  int    // Head sprite for players
-	Weapon      int    // Weapon sprite
-	Shield      int    // Shield sprite
-	HeadTop     int    // Headgear top
-	HeadMid     int    // Headgear mid
-	HeadBottom  int    // Headgear bottom
-	HairStyle   int    // Hair style
-	HairColor   int    // Hair color
-	ClothesColor int   // Clothes color
-	BodyPalette int    // Body palette
+	SpriteID     int // Base sprite ID (job ID for players, monster ID for mobs)
+	HeadSprite   int // Head sprite for players
+	Weapon       int // Weapon sprite
+	Shield       int // Shield sprite
+	HeadTop      int // Headgear top
+	HeadMid      int // Headgear mid
+	HeadBottom   int // Headgear bottom
+	HairStyle    int // Hair style
+	HairColor    int // Hair color
+	ClothesColor int // Clothes color
+	BodyPalette  int // Body palette
 
 	// Display properties
-	ShowHP      bool    // Whether to show HP bar
-	ShowName    bool    // Whether to show name
+	ShowHP      bool       // Whether to show HP bar
+	ShowName    bool       // Whether to show name
 	NameColor   [4]float32 // Name display color (RGBA)
-	GuildName   string  // Guild name (for players)
-	GuildEmblem int     // Guild emblem ID
-	Title       string  // Title/party name
+	GuildName   string     // Guild name (for players)
+	GuildEmblem int        // Guild emblem ID
+	Title       string     // Title/party name
 
 	// Stats (for players/monsters)
 	Level int
@@ -70,21 +70,21 @@ type Entity struct {
 	Job   int // Job/class ID
 
 	// Movement
-	MoveSpeed    float64
-	MovePath     []math.Vec2
+	MoveSpeed     float64
+	MovePath      []math.Vec2
 	MoveStartTime float64 // When movement started
 	MoveEndTime   float64 // When movement should end
 
 	// Animation
-	AnimAction   int     // Current animation action
-	AnimFrame    int     // Current frame
-	AnimTime     float64 // Time in current animation
-	AnimSpeed    float64 // Animation speed multiplier
+	AnimAction int     // Current animation action
+	AnimFrame  int     // Current frame
+	AnimTime   float64 // Time in current animation
+	AnimSpeed  float64 // Animation speed multiplier
 
 	// Combat
-	AttackSpeed  int     // Attack speed (ASPD)
-	AttackRange  int     // Attack range
-	TargetID     uint32  // Current target
+	AttackSpeed int    // Attack speed (ASPD)
+	AttackRange int    // Attack range
+	TargetID    uint32 // Current target
 
 	// Flags
 	IsVisible    bool
@@ -95,13 +95,13 @@ type Entity struct {
 // NewEntity creates a new entity.
 func NewEntity(id uint32, entityType Type) *Entity {
 	e := &Entity{
-		ID:          id,
-		Type:        entityType,
-		MoveSpeed:   1.0,
-		AnimSpeed:   1.0,
-		IsVisible:   true,
+		ID:           id,
+		Type:         entityType,
+		MoveSpeed:    1.0,
+		AnimSpeed:    1.0,
+		IsVisible:    true,
 		IsTargetable: true,
-		NameColor:   [4]float32{1, 1, 1, 1}, // White by default
+		NameColor:    [4]float32{1, 1, 1, 1}, // White by default
 	}
 
 	// Set default display properties based on type
@@ -191,12 +191,6 @@ func (e *Entity) Heal(amount int) {
 func (e *Entity) Update(dt float64) {
 	// Update animation time
 	e.AnimTime += dt * e.AnimSpeed
-
-	// Process movement path if any
-	if len(e.MovePath) > 0 && e.State == StateWalking {
-		// Movement processing would be handled by the movement controller
-		// This is just for animation state updates
-	}
 
 	// Update state based on conditions
 	if e.IsDead && e.State != StateDead {

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -30,7 +30,7 @@ var koreanGlyphRanges = []imgui.Wchar{
 	0x3000, 0x30FF, // CJK Symbols and Punctuation, Hiragana, Katakana
 	0x3130, 0x318F, // Hangul Compatibility Jamo
 	0xAC00, 0xD7AF, // Hangul Syllables
-	0,              // Terminator
+	0, // Terminator
 }
 
 // Game is the main game instance.
@@ -342,7 +342,7 @@ func (g *Game) renderUI() {
 			},
 			OnLogin: func() {
 				g.pendingAction = func() {
-					state.AttemptLogin()
+					_ = state.AttemptLogin()
 				}
 			},
 		}, viewportWidth, viewportHeight)
@@ -363,7 +363,7 @@ func (g *Game) renderUI() {
 			IsReady:       state.IsCharListReady(),
 			OnSelect: func(index int) {
 				g.pendingAction = func() {
-					state.SelectCharacter(index)
+					_ = state.SelectCharacter(index)
 				}
 			},
 		}, viewportWidth, viewportHeight)
@@ -688,7 +688,7 @@ func parseHostPort(addr string) (string, int) {
 		for i := len(addr) - 1; i >= 0; i-- {
 			if addr[i] == ':' {
 				host = addr[:i]
-				fmt.Sscanf(addr[i+1:], "%d", &port)
+				_, _ = fmt.Sscanf(addr[i+1:], "%d", &port)
 				break
 			}
 		}

--- a/internal/game/states/charselect.go
+++ b/internal/game/states/charselect.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/Faultbox/midgard-ro/internal/logger"
 	"github.com/Faultbox/midgard-ro/internal/network"
 	"github.com/Faultbox/midgard-ro/internal/network/packets"
-	"go.uber.org/zap"
 )
 
 // CharSelectStateConfig contains configuration for character selection.

--- a/internal/game/states/charselect.go
+++ b/internal/game/states/charselect.go
@@ -24,10 +24,10 @@ type CharSelectState struct {
 	manager *Manager
 
 	// Character data
-	Characters    []*packets.CharInfo
-	SelectedSlot  int
-	MaxSlots      int
-	AvailSlots    int
+	Characters   []*packets.CharInfo
+	SelectedSlot int
+	MaxSlots     int
+	AvailSlots   int
 
 	// State
 	IsLoading     bool

--- a/internal/game/states/connecting.go
+++ b/internal/game/states/connecting.go
@@ -10,18 +10,18 @@ import (
 
 // ConnectingStateConfig contains configuration for the connecting state.
 type ConnectingStateConfig struct {
-	NextState   string // State to transition to after connecting
-	ServerHost  string // Server to connect to (for char/map server)
-	ServerPort  int
-	Timeout     time.Duration
-	MapName     string // Map name (for ingame transition)
+	NextState  string // State to transition to after connecting
+	ServerHost string // Server to connect to (for char/map server)
+	ServerPort int
+	Timeout    time.Duration
+	MapName    string // Map name (for ingame transition)
 }
 
 // ConnectingState handles connection transitions between servers.
 type ConnectingState struct {
-	config    ConnectingStateConfig
-	client    *network.Client
-	manager   *Manager
+	config  ConnectingStateConfig
+	client  *network.Client
+	manager *Manager
 
 	// Connection state
 	startTime time.Time

--- a/internal/game/states/ingame.go
+++ b/internal/game/states/ingame.go
@@ -150,10 +150,7 @@ func (s *InGameState) loadMap() error {
 	}
 
 	// Get base map name (remove .gat extension)
-	baseName := s.MapName
-	if strings.HasSuffix(baseName, ".gat") {
-		baseName = baseName[:len(baseName)-4]
-	}
+	baseName := strings.TrimSuffix(s.MapName, ".gat")
 
 	// Load GND (terrain)
 	gndPath := "data\\" + baseName + ".gnd"

--- a/internal/game/states/ingame.go
+++ b/internal/game/states/ingame.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/Faultbox/midgard-ro/internal/engine/camera"
 	"github.com/Faultbox/midgard-ro/internal/engine/scene"
 	"github.com/Faultbox/midgard-ro/internal/game/entity"
@@ -13,7 +15,6 @@ import (
 	"github.com/Faultbox/midgard-ro/internal/network"
 	"github.com/Faultbox/midgard-ro/internal/network/packets"
 	"github.com/Faultbox/midgard-ro/pkg/formats"
-	"go.uber.org/zap"
 )
 
 // InGameStateConfig contains configuration for the in-game state.

--- a/internal/game/states/loading.go
+++ b/internal/game/states/loading.go
@@ -14,12 +14,12 @@ import (
 
 // LoadingStateConfig contains configuration for the loading state.
 type LoadingStateConfig struct {
-	MapName    string
-	SpawnX     int
-	SpawnY     int
-	SpawnDir   uint8
-	CharID     uint32
-	TexLoader  func(string) ([]byte, error) // Function to load textures from GRF
+	MapName   string
+	SpawnX    int
+	SpawnY    int
+	SpawnDir  uint8
+	CharID    uint32
+	TexLoader func(string) ([]byte, error) // Function to load textures from GRF
 }
 
 // LoadingState handles map loading before entering the game.
@@ -29,11 +29,11 @@ type LoadingState struct {
 	manager *Manager
 
 	// Loading progress
-	StatusMsg     string
-	ErrorMsg      string
-	Progress      float32 // 0.0 to 1.0
-	LoadingPhase  string
-	IsComplete    bool
+	StatusMsg    string
+	ErrorMsg     string
+	Progress     float32 // 0.0 to 1.0
+	LoadingPhase string
+	IsComplete   bool
 
 	// Loaded data (passed to InGame state)
 	MapLoaded bool
@@ -185,7 +185,7 @@ func (s *LoadingState) sendLoadingComplete() {
 	pkt := &packets.LoadingComplete{
 		PacketID: packets.CZ_NOTIFY_ACTORINIT,
 	}
-	s.client.Send(pkt.Encode())
+	_ = s.client.Send(pkt.Encode())
 }
 
 func (s *LoadingState) transitionToInGame() {
@@ -201,11 +201,7 @@ func (s *LoadingState) transitionToInGame() {
 
 func (s *LoadingState) getDisplayMapName() string {
 	// Remove .gat extension for display
-	name := s.config.MapName
-	if strings.HasSuffix(name, ".gat") {
-		name = name[:len(name)-4]
-	}
-	return name
+	return strings.TrimSuffix(s.config.MapName, ".gat")
 }
 
 // GetStatusMessage returns the current status message.

--- a/internal/game/states/loading.go
+++ b/internal/game/states/loading.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/Faultbox/midgard-ro/internal/logger"
 	"github.com/Faultbox/midgard-ro/internal/network"
 	"github.com/Faultbox/midgard-ro/internal/network/packets"
-	"go.uber.org/zap"
 )
 
 // LoadingStateConfig contains configuration for the loading state.

--- a/internal/game/states/login.go
+++ b/internal/game/states/login.go
@@ -19,27 +19,27 @@ type LoginStateConfig struct {
 
 // LoginState handles the login screen and authentication.
 type LoginState struct {
-	config     LoginStateConfig
-	client     *network.Client
-	manager    *Manager
+	config  LoginStateConfig
+	client  *network.Client
+	manager *Manager
 
 	// UI state
-	Username   string
-	Password   string
-	ErrorMsg   string
-	IsLoading  bool
+	Username  string
+	Password  string
+	ErrorMsg  string
+	IsLoading bool
 
 	// Connection state
-	connected  bool
-	loginSent  bool
+	connected bool
+	loginSent bool
 }
 
 // NewLoginState creates a new login state.
 func NewLoginState(cfg LoginStateConfig, client *network.Client, manager *Manager) *LoginState {
 	return &LoginState{
-		config:  cfg,
-		client:  client,
-		manager: manager,
+		config:   cfg,
+		client:   client,
+		manager:  manager,
 		Username: cfg.Username,
 		Password: cfg.Password,
 	}

--- a/internal/game/ui/charselect_ui.go
+++ b/internal/game/ui/charselect_ui.go
@@ -171,26 +171,22 @@ func (ui *CharSelectUI) renderActionButtons() {
 	// Select button
 	imgui.BeginDisabledV(ui.selectedIndex < 0 || ui.state.IsLoadingState())
 	if imgui.ButtonV("Enter Game", imgui.NewVec2(150, 30)) {
-		ui.state.SelectCharacter(ui.selectedIndex)
+		_ = ui.state.SelectCharacter(ui.selectedIndex)
 	}
 	imgui.EndDisabled()
 
 	imgui.SameLine()
 
-	// Create character button (placeholder)
+	// Create character button (placeholder, always disabled for MVP)
 	imgui.BeginDisabledV(true)
-	if imgui.ButtonV("Create Character", imgui.NewVec2(150, 0)) {
-		// TODO: Character creation
-	}
+	imgui.ButtonV("Create Character", imgui.NewVec2(150, 0))
 	imgui.EndDisabled()
 
 	imgui.SameLine()
 
-	// Delete character button (placeholder)
+	// Delete character button (placeholder, always disabled for MVP)
 	imgui.BeginDisabledV(true)
-	if imgui.ButtonV("Delete Character", imgui.NewVec2(150, 0)) {
-		// TODO: Character deletion
-	}
+	imgui.ButtonV("Delete Character", imgui.NewVec2(150, 0))
 	imgui.EndDisabled()
 }
 
@@ -291,7 +287,7 @@ func getJobName(jobID uint16) string {
 		4070: "Sura",
 		4071: "Genetic",
 		4072: "Shadow Chaser",
-		4073: "Royal Guard (Gryphon)",
+		4073: "Royal Guard (Gryphon)", //nolint:misspell // "Gryphon" is the RO Royal Guard mount name
 	}
 
 	if name, ok := jobs[jobID]; ok {

--- a/internal/game/ui/chatbox.go
+++ b/internal/game/ui/chatbox.go
@@ -21,13 +21,13 @@ type ChatMessage struct {
 type ChatChannel uint8
 
 const (
-	ChatChannelNormal ChatChannel = iota // White - normal chat
-	ChatChannelParty                     // Green - party chat
-	ChatChannelGuild                     // Yellow - guild chat
-	ChatChannelWhisper                   // Pink - whisper
-	ChatChannelGlobal                    // Orange - global/world chat
-	ChatChannelSystem                    // Red - system messages
-	ChatChannelAnnounce                  // Blue - server announcements
+	ChatChannelNormal   ChatChannel = iota // White - normal chat
+	ChatChannelParty                       // Green - party chat
+	ChatChannelGuild                       // Yellow - guild chat
+	ChatChannelWhisper                     // Pink - whisper
+	ChatChannelGlobal                      // Orange - global/world chat
+	ChatChannelSystem                      // Red - system messages
+	ChatChannelAnnounce                    // Blue - server announcements
 )
 
 // ChatBox renders the game chat interface.

--- a/internal/game/ui/debug_overlay.go
+++ b/internal/game/ui/debug_overlay.go
@@ -32,11 +32,11 @@ type DebugOverlay struct {
 	MapHeight int
 
 	// Entity counts
-	EntityCount   int
-	PlayerCount   int
-	MonsterCount  int
-	NPCCount      int
-	ItemCount     int
+	EntityCount  int
+	PlayerCount  int
+	MonsterCount int
+	NPCCount     int
+	ItemCount    int
 
 	// Network stats
 	PacketsSent     int
@@ -46,30 +46,30 @@ type DebugOverlay struct {
 	Ping            int
 
 	// Render stats
-	DrawCalls    int
-	Triangles    int
+	DrawCalls       int
+	Triangles       int
 	TextureSwitches int
 
 	// Display toggles
-	ShowFPS       bool
-	ShowPosition  bool
-	ShowEntityInfo bool
+	ShowFPS         bool
+	ShowPosition    bool
+	ShowEntityInfo  bool
 	ShowNetworkInfo bool
-	ShowRenderInfo bool
-	ShowMemory    bool
-	Enabled       bool
+	ShowRenderInfo  bool
+	ShowMemory      bool
+	Enabled         bool
 }
 
 // NewDebugOverlay creates a new debug overlay.
 func NewDebugOverlay() *DebugOverlay {
 	return &DebugOverlay{
-		ShowFPS:       true,
-		ShowPosition:  true,
-		ShowEntityInfo: false,
+		ShowFPS:         true,
+		ShowPosition:    true,
+		ShowEntityInfo:  false,
 		ShowNetworkInfo: false,
-		ShowRenderInfo: false,
-		ShowMemory:    false,
-		Enabled:       true,
+		ShowRenderInfo:  false,
+		ShowMemory:      false,
+		Enabled:         true,
 	}
 }
 

--- a/internal/game/ui/ingame_ui.go
+++ b/internal/game/ui/ingame_ui.go
@@ -22,27 +22,27 @@ type InGameUI struct {
 	entityHPBar  *EntityHPBar
 
 	// Settings
-	ShowDebugInfo    bool
-	ShowMinimap      bool
-	ShowChat         bool
-	ShowStatusBar    bool
-	ShowEntityBars   bool
+	ShowDebugInfo  bool
+	ShowMinimap    bool
+	ShowChat       bool
+	ShowStatusBar  bool
+	ShowEntityBars bool
 }
 
 // NewInGameUI creates a new in-game UI.
 func NewInGameUI(state *states.InGameState) *InGameUI {
 	return &InGameUI{
-		state:            state,
-		statusBar:        NewStatusBar(),
-		minimap:          NewMinimap(),
-		chatBox:          NewChatBox(),
-		debugOverlay:     NewDebugOverlay(),
-		entityHPBar:      NewEntityHPBar(),
-		ShowDebugInfo:    true, // Show debug info by default during development
-		ShowMinimap:      true,
-		ShowChat:         true,
-		ShowStatusBar:    true,
-		ShowEntityBars:   true,
+		state:          state,
+		statusBar:      NewStatusBar(),
+		minimap:        NewMinimap(),
+		chatBox:        NewChatBox(),
+		debugOverlay:   NewDebugOverlay(),
+		entityHPBar:    NewEntityHPBar(),
+		ShowDebugInfo:  true, // Show debug info by default during development
+		ShowMinimap:    true,
+		ShowChat:       true,
+		ShowStatusBar:  true,
+		ShowEntityBars: true,
 	}
 }
 

--- a/internal/game/ui/login_ui.go
+++ b/internal/game/ui/login_ui.go
@@ -87,7 +87,7 @@ func (ui *LoginUI) renderContent() {
 	// Login button (full width)
 	imgui.BeginDisabledV(ui.state.IsLoadingState())
 	if imgui.ButtonV("Login", imgui.NewVec2(-1, 30)) {
-		ui.state.AttemptLogin()
+		_ = ui.state.AttemptLogin()
 	}
 	imgui.EndDisabled()
 

--- a/internal/game/ui/minimap.go
+++ b/internal/game/ui/minimap.go
@@ -33,10 +33,10 @@ type Minimap struct {
 
 // MinimapMarker represents a point of interest on the minimap.
 type MinimapMarker struct {
-	X, Y  int           // Tile position
-	Type  MarkerType    // Type of marker
-	Color imgui.Vec4    // Display color
-	Label string        // Optional label
+	X, Y  int        // Tile position
+	Type  MarkerType // Type of marker
+	Color imgui.Vec4 // Display color
+	Label string     // Optional label
 }
 
 // MarkerType defines the type of minimap marker.
@@ -234,19 +234,19 @@ func (m *Minimap) renderMarker(drawList *imgui.DrawList, cursorPos imgui.Vec2, o
 
 func (m *Minimap) drawDiamond(drawList *imgui.DrawList, x, y, size float32, color uint32) {
 	drawList.AddQuadFilled(
-		imgui.NewVec2(x, y-size),     // Top
-		imgui.NewVec2(x+size, y),     // Right
-		imgui.NewVec2(x, y+size),     // Bottom
-		imgui.NewVec2(x-size, y),     // Left
+		imgui.NewVec2(x, y-size), // Top
+		imgui.NewVec2(x+size, y), // Right
+		imgui.NewVec2(x, y+size), // Bottom
+		imgui.NewVec2(x-size, y), // Left
 		color,
 	)
 }
 
 func (m *Minimap) drawTriangle(drawList *imgui.DrawList, x, y, size float32, color uint32) {
 	drawList.AddTriangleFilled(
-		imgui.NewVec2(x, y-size),       // Top
-		imgui.NewVec2(x+size, y+size),  // Bottom right
-		imgui.NewVec2(x-size, y+size),  // Bottom left
+		imgui.NewVec2(x, y-size),      // Top
+		imgui.NewVec2(x+size, y+size), // Bottom right
+		imgui.NewVec2(x-size, y+size), // Bottom left
 		color,
 	)
 }

--- a/internal/game/world/movement.go
+++ b/internal/game/world/movement.go
@@ -47,7 +47,7 @@ func (mc *MovementController) MoveTo(destTileX, destTileY int) [][2]int {
 
 	// Find path
 	path := mc.pathFinder.FindPath(currentTileX, currentTileY, destTileX, destTileY)
-	if path == nil || len(path) == 0 {
+	if len(path) == 0 {
 		return nil
 	}
 

--- a/internal/game/world/pathfinding.go
+++ b/internal/game/world/pathfinding.go
@@ -30,7 +30,7 @@ func (h PathHeap) Swap(i, j int) {
 
 func (h *PathHeap) Push(x interface{}) {
 	n := len(*h)
-	node := x.(*PathNode)
+	node, _ := x.(*PathNode)
 	node.Index = n
 	*h = append(*h, node)
 }
@@ -122,7 +122,7 @@ func (pf *PathFinder) FindPath(startX, startY, goalX, goalY int) [][2]int {
 		iterations++
 
 		// Get node with lowest F score
-		current := heap.Pop(openSet).(*PathNode)
+		current, _ := heap.Pop(openSet).(*PathNode)
 
 		// Check if we reached the goal
 		if current.X == goalX && current.Y == goalY {

--- a/internal/game/world/pathfinding_test.go
+++ b/internal/game/world/pathfinding_test.go
@@ -6,8 +6,12 @@ import (
 	"github.com/Faultbox/midgard-ro/pkg/formats"
 )
 
-// mockGAT creates a simple square GAT for testing.
-func mockGAT(size int, blocked [][2]int) *formats.GAT {
+// mockGATSize is the side length of the square test grid.
+const mockGATSize = 5
+
+// mockGAT creates a 5x5 GAT for testing.
+func mockGAT(blocked [][2]int) *formats.GAT {
+	const size = mockGATSize
 	gat := &formats.GAT{
 		Width:  uint32(size),
 		Height: uint32(size),
@@ -32,7 +36,7 @@ func mockGAT(size int, blocked [][2]int) *formats.GAT {
 
 func TestPathFinder_FindPath_Simple(t *testing.T) {
 	// 5x5 grid, no obstacles
-	gat := mockGAT(5, nil)
+	gat := mockGAT(nil)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(0, 0, 4, 4)
@@ -56,7 +60,7 @@ func TestPathFinder_FindPath_WithObstacle(t *testing.T) {
 	blocked := [][2]int{
 		{2, 0}, {2, 1}, {2, 2}, {2, 3},
 	}
-	gat := mockGAT(5, blocked)
+	gat := mockGAT(blocked)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(0, 2, 4, 2)
@@ -77,7 +81,7 @@ func TestPathFinder_FindPath_NoPath(t *testing.T) {
 	blocked := [][2]int{
 		{2, 0}, {2, 1}, {2, 2}, {2, 3}, {2, 4},
 	}
-	gat := mockGAT(5, blocked)
+	gat := mockGAT(blocked)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(0, 2, 4, 2)
@@ -87,7 +91,7 @@ func TestPathFinder_FindPath_NoPath(t *testing.T) {
 }
 
 func TestPathFinder_FindPath_SameStartGoal(t *testing.T) {
-	gat := mockGAT(5, nil)
+	gat := mockGAT(nil)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(2, 2, 2, 2)
@@ -101,7 +105,7 @@ func TestPathFinder_FindPath_SameStartGoal(t *testing.T) {
 }
 
 func TestPathFinder_FindPath_OutOfBounds(t *testing.T) {
-	gat := mockGAT(5, nil)
+	gat := mockGAT(nil)
 	pf := NewPathFinder(gat)
 
 	// Start out of bounds
@@ -119,7 +123,7 @@ func TestPathFinder_FindPath_OutOfBounds(t *testing.T) {
 
 func TestPathFinder_FindPath_BlockedGoal(t *testing.T) {
 	blocked := [][2]int{{4, 4}}
-	gat := mockGAT(5, blocked)
+	gat := mockGAT(blocked)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(0, 0, 4, 4)
@@ -130,7 +134,7 @@ func TestPathFinder_FindPath_BlockedGoal(t *testing.T) {
 
 func TestPathFinder_IsWalkable(t *testing.T) {
 	blocked := [][2]int{{2, 2}}
-	gat := mockGAT(5, blocked)
+	gat := mockGAT(blocked)
 	pf := NewPathFinder(gat)
 
 	if pf.IsWalkable(2, 2) {

--- a/internal/game/world/pathfinding_test.go
+++ b/internal/game/world/pathfinding_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/Faultbox/midgard-ro/pkg/formats"
 )
 
-// mockGAT creates a simple GAT for testing.
-func mockGAT(width, height int, blocked [][2]int) *formats.GAT {
+// mockGAT creates a simple square GAT for testing.
+func mockGAT(size int, blocked [][2]int) *formats.GAT {
 	gat := &formats.GAT{
-		Width:  uint32(width),
-		Height: uint32(height),
-		Cells:  make([]formats.GATCell, width*height),
+		Width:  uint32(size),
+		Height: uint32(size),
+		Cells:  make([]formats.GATCell, size*size),
 	}
 
 	// Mark all cells as walkable by default
@@ -21,7 +21,7 @@ func mockGAT(width, height int, blocked [][2]int) *formats.GAT {
 
 	// Mark blocked cells
 	for _, b := range blocked {
-		idx := b[1]*width + b[0]
+		idx := b[1]*size + b[0]
 		if idx >= 0 && idx < len(gat.Cells) {
 			gat.Cells[idx].Type = formats.GATBlocked
 		}
@@ -32,7 +32,7 @@ func mockGAT(width, height int, blocked [][2]int) *formats.GAT {
 
 func TestPathFinder_FindPath_Simple(t *testing.T) {
 	// 5x5 grid, no obstacles
-	gat := mockGAT(5, 5, nil)
+	gat := mockGAT(5, nil)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(0, 0, 4, 4)
@@ -56,7 +56,7 @@ func TestPathFinder_FindPath_WithObstacle(t *testing.T) {
 	blocked := [][2]int{
 		{2, 0}, {2, 1}, {2, 2}, {2, 3},
 	}
-	gat := mockGAT(5, 5, blocked)
+	gat := mockGAT(5, blocked)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(0, 2, 4, 2)
@@ -77,7 +77,7 @@ func TestPathFinder_FindPath_NoPath(t *testing.T) {
 	blocked := [][2]int{
 		{2, 0}, {2, 1}, {2, 2}, {2, 3}, {2, 4},
 	}
-	gat := mockGAT(5, 5, blocked)
+	gat := mockGAT(5, blocked)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(0, 2, 4, 2)
@@ -87,11 +87,11 @@ func TestPathFinder_FindPath_NoPath(t *testing.T) {
 }
 
 func TestPathFinder_FindPath_SameStartGoal(t *testing.T) {
-	gat := mockGAT(5, 5, nil)
+	gat := mockGAT(5, nil)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(2, 2, 2, 2)
-	if path == nil || len(path) == 0 {
+	if len(path) == 0 {
 		t.Fatal("expected path with single node")
 	}
 
@@ -101,7 +101,7 @@ func TestPathFinder_FindPath_SameStartGoal(t *testing.T) {
 }
 
 func TestPathFinder_FindPath_OutOfBounds(t *testing.T) {
-	gat := mockGAT(5, 5, nil)
+	gat := mockGAT(5, nil)
 	pf := NewPathFinder(gat)
 
 	// Start out of bounds
@@ -119,7 +119,7 @@ func TestPathFinder_FindPath_OutOfBounds(t *testing.T) {
 
 func TestPathFinder_FindPath_BlockedGoal(t *testing.T) {
 	blocked := [][2]int{{4, 4}}
-	gat := mockGAT(5, 5, blocked)
+	gat := mockGAT(5, blocked)
 	pf := NewPathFinder(gat)
 
 	path := pf.FindPath(0, 0, 4, 4)
@@ -130,7 +130,7 @@ func TestPathFinder_FindPath_BlockedGoal(t *testing.T) {
 
 func TestPathFinder_IsWalkable(t *testing.T) {
 	blocked := [][2]int{{2, 2}}
-	gat := mockGAT(5, 5, blocked)
+	gat := mockGAT(5, blocked)
 	pf := NewPathFinder(gat)
 
 	if pf.IsWalkable(2, 2) {

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -88,7 +88,7 @@ func (c *Client) Connect(host string, port int, serverType ServerType) error {
 	c.conn = conn
 	c.connected = true
 	c.serverType = serverType
-	c.readOffset = 0 // Reset read buffer
+	c.readOffset = 0                      // Reset read buffer
 	c.charServerAccountIDReceived = false // Reset for new connection
 
 	logger.Info("connected to server", zap.String("addr", addr))
@@ -164,7 +164,7 @@ func (c *Client) Process() (err error) {
 	c.mu.Unlock()
 
 	// Set short read deadline for non-blocking behavior
-	conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
+	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
 
 	// Read available data
 	n, err := conn.Read(c.readBuf[c.readOffset:])

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -10,8 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Faultbox/midgard-ro/internal/logger"
 	"go.uber.org/zap"
+
+	"github.com/Faultbox/midgard-ro/internal/logger"
 )
 
 // ServerType represents the type of server.

--- a/internal/network/packets/packets.go
+++ b/internal/network/packets/packets.go
@@ -29,11 +29,11 @@ const (
 	CH_DELETE_CHAR uint16 = 0x0068 // Delete character
 
 	// Char Server -> Client
-	HC_ACCEPT_ENTER     uint16 = 0x006B // Enter accepted + char list
-	HC_REFUSE_ENTER     uint16 = 0x006C // Enter refused
-	HC_ACCEPT_MAKECHAR  uint16 = 0x006D // Character created
-	HC_NOTIFY_ZONESVR   uint16 = 0x0071 // Map server info (old)
-	HC_NOTIFY_ZONESVR2  uint16 = 0x0AC5 // Map server info (modern rAthena)
+	HC_ACCEPT_ENTER    uint16 = 0x006B // Enter accepted + char list
+	HC_REFUSE_ENTER    uint16 = 0x006C // Enter refused
+	HC_ACCEPT_MAKECHAR uint16 = 0x006D // Character created
+	HC_NOTIFY_ZONESVR  uint16 = 0x0071 // Map server info (old)
+	HC_NOTIFY_ZONESVR2 uint16 = 0x0AC5 // Map server info (modern rAthena)
 )
 
 // Packet IDs for map server
@@ -236,9 +236,9 @@ func DecodeCharInfo(data []byte) *CharInfo {
 
 	c := &CharInfo{
 		CharID:       readU32(data, 0),
-		BaseExp:      uint32(readU32(data, 4)),
-		Zeny:         uint32(readU32(data, 12)),
-		JobExp:       uint32(readU32(data, 20)),
+		BaseExp:      readU32(data, 4),
+		Zeny:         readU32(data, 12),
+		JobExp:       readU32(data, 20),
 		JobLevel:     readU32(data, 28),
 		BodyState:    0,
 		HealthState:  0,
@@ -246,16 +246,16 @@ func DecodeCharInfo(data []byte) *CharInfo {
 		Virtue:       0,
 		Honor:        0,
 		StatusPoint:  0,
-		HP:           uint32(readU16(data, 66)),  // HP at offset 66
-		MaxHP:        uint32(readU16(data, 74)),  // MaxHP at offset 74
-		SP:           readU16(data, 58),          // SP at offset 58
-		MaxSP:        readU16(data, 58),          // Assume same as SP for now
-		WalkSpeed:    readU16(data, 82),          // WalkSpeed at offset 82
-		Class:        readU16(data, 50),          // Class at offset 50
+		HP:           uint32(readU16(data, 66)), // HP at offset 66
+		MaxHP:        uint32(readU16(data, 74)), // MaxHP at offset 74
+		SP:           readU16(data, 58),         // SP at offset 58
+		MaxSP:        readU16(data, 58),         // Assume same as SP for now
+		WalkSpeed:    readU16(data, 82),         // WalkSpeed at offset 82
+		Class:        readU16(data, 50),         // Class at offset 50
 		HairStyle:    readU16(data, 84),
 		Body:         readU16(data, 86),
 		Weapon:       readU16(data, 88),
-		BaseLevel:    readU16(data, 90),          // BaseLevel at offset 90
+		BaseLevel:    readU16(data, 90), // BaseLevel at offset 90
 		SkillPoint:   0,
 		HeadBottom:   0,
 		Shield:       0,
@@ -440,13 +440,13 @@ func (p *MapEnter) Encode() []byte {
 // MapEnter2 (CZ_ENTER2 0x0436) packet - modern rAthena (Korangar format).
 // Note: This does NOT include auth token - it uses 4 unknown bytes instead.
 type MapEnter2 struct {
-	PacketID   uint16    // 0x0436
+	PacketID   uint16 // 0x0436
 	AccountID  uint32
 	CharID     uint32
 	LoginID1   uint32
 	ClientTick uint32
 	Sex        uint8
-	Unknown    [4]byte   // Always zeros
+	Unknown    [4]byte // Always zeros
 }
 
 // Size returns packet size.
@@ -474,7 +474,7 @@ type MapAccept struct {
 	StartTime uint32
 	PosDir    [3]byte // Packed position and direction
 	Unknown   [2]byte
-	Font      uint16  // Only in ZC_ACCEPT_ENTER2
+	Font      uint16 // Only in ZC_ACCEPT_ENTER2
 }
 
 // DecodeMapAccept decodes the map enter accept packet.
@@ -507,7 +507,7 @@ func (p *MapAccept) GetPosition() (x, y int, dir uint8) {
 
 // MoveRequest (CZ_REQUEST_MOVE 0x0085) packet.
 type MoveRequest struct {
-	PacketID uint16 // 0x0085
+	PacketID uint16  // 0x0085
 	Dest     [3]byte // Packed destination
 }
 

--- a/internal/network/packets/packets_test.go
+++ b/internal/network/packets/packets_test.go
@@ -167,11 +167,11 @@ func TestCharInfoDecode(t *testing.T) {
 	data[2] = 0x02
 	data[3] = 0x00
 
-	// Set name at offset 80
-	copy(data[80:104], "TestChar\x00")
+	// Set name at offset 108
+	copy(data[108:132], "TestChar\x00")
 
-	// Set slot at offset 110
-	data[110] = 3
+	// Set slot at offset 138
+	data[138] = 3
 
 	info := DecodeCharInfo(data)
 	if info == nil {

--- a/pkg/formats/testdata/generate_act.go
+++ b/pkg/formats/testdata/generate_act.go
@@ -16,10 +16,10 @@ func main() {
 
 	// Header (16 bytes)
 	buf.WriteString("AC")
-	buf.WriteByte(0x05)                                    // minor
-	buf.WriteByte(0x02)                                    // major (version 2.5)
-	binary.Write(&buf, binary.LittleEndian, uint16(2))     // 2 actions
-	buf.Write(make([]byte, 10))                            // reserved
+	buf.WriteByte(0x05)                                // minor
+	buf.WriteByte(0x02)                                // major (version 2.5)
+	binary.Write(&buf, binary.LittleEndian, uint16(2)) // 2 actions
+	buf.Write(make([]byte, 10))                        // reserved
 
 	// Action 0: idle (1 frame, 1 layer)
 	binary.Write(&buf, binary.LittleEndian, uint32(1)) // 1 frame
@@ -27,8 +27,8 @@ func main() {
 
 	// Action 1: walk (2 frames, 1 layer each)
 	binary.Write(&buf, binary.LittleEndian, uint32(2)) // 2 frames
-	writeFrame(&buf, 1, 1, false)                       // frame 0, sprite 1, event=1
-	writeFrame(&buf, 2, -1, false)                      // frame 1, sprite 2, no event
+	writeFrame(&buf, 1, 1, false)                      // frame 0, sprite 1, event=1
+	writeFrame(&buf, 2, -1, false)                     // frame 1, sprite 2, no event
 
 	// Events (1 event)
 	binary.Write(&buf, binary.LittleEndian, int32(1))
@@ -59,17 +59,17 @@ func writeFrame(buf *bytes.Buffer, spriteID, eventID int, withAnchor bool) {
 	binary.Write(buf, binary.LittleEndian, uint32(1))
 
 	// Layer
-	binary.Write(buf, binary.LittleEndian, int32(0))           // X
-	binary.Write(buf, binary.LittleEndian, int32(0))           // Y
-	binary.Write(buf, binary.LittleEndian, int32(spriteID))    // sprite ID
-	binary.Write(buf, binary.LittleEndian, uint32(0))          // flags
-	buf.Write([]byte{255, 255, 255, 255})                      // color RGBA
-	binary.Write(buf, binary.LittleEndian, float32(1.0))       // scale X
-	binary.Write(buf, binary.LittleEndian, float32(1.0))       // scale Y (v0x204+)
-	binary.Write(buf, binary.LittleEndian, float32(0.0))       // rotation
-	binary.Write(buf, binary.LittleEndian, int32(0))           // sprite type
-	binary.Write(buf, binary.LittleEndian, int32(32))          // width (v0x205+)
-	binary.Write(buf, binary.LittleEndian, int32(32))          // height (v0x205+)
+	binary.Write(buf, binary.LittleEndian, int32(0))        // X
+	binary.Write(buf, binary.LittleEndian, int32(0))        // Y
+	binary.Write(buf, binary.LittleEndian, int32(spriteID)) // sprite ID
+	binary.Write(buf, binary.LittleEndian, uint32(0))       // flags
+	buf.Write([]byte{255, 255, 255, 255})                   // color RGBA
+	binary.Write(buf, binary.LittleEndian, float32(1.0))    // scale X
+	binary.Write(buf, binary.LittleEndian, float32(1.0))    // scale Y (v0x204+)
+	binary.Write(buf, binary.LittleEndian, float32(0.0))    // rotation
+	binary.Write(buf, binary.LittleEndian, int32(0))        // sprite type
+	binary.Write(buf, binary.LittleEndian, int32(32))       // width (v0x205+)
+	binary.Write(buf, binary.LittleEndian, int32(32))       // height (v0x205+)
 
 	// Event ID
 	binary.Write(buf, binary.LittleEndian, int32(eventID))

--- a/pkg/formats/testdata/generate_spr.go
+++ b/pkg/formats/testdata/generate_spr.go
@@ -16,15 +16,15 @@ func main() {
 
 	// Header
 	buf.WriteString("SP")
-	buf.WriteByte(1)                                       // minor = 1
-	buf.WriteByte(2)                                       // major = 2 (so version 2.1)
-	binary.Write(&buf, binary.LittleEndian, uint16(2))     // 2 indexed images
-	binary.Write(&buf, binary.LittleEndian, uint16(1))     // 1 true-color image
+	buf.WriteByte(1)                                   // minor = 1
+	buf.WriteByte(2)                                   // major = 2 (so version 2.1)
+	binary.Write(&buf, binary.LittleEndian, uint16(2)) // 2 indexed images
+	binary.Write(&buf, binary.LittleEndian, uint16(1)) // 1 true-color image
 
 	// Indexed image 1: 4x4 with RLE compression
 	// Pattern: checkerboard of transparent (0) and color 1
-	binary.Write(&buf, binary.LittleEndian, uint16(4))     // width
-	binary.Write(&buf, binary.LittleEndian, uint16(4))     // height
+	binary.Write(&buf, binary.LittleEndian, uint16(4)) // width
+	binary.Write(&buf, binary.LittleEndian, uint16(4)) // height
 	// RLE data for: 0,1,0,1, 1,0,1,0, 0,1,0,1, 1,0,1,0 (checkerboard)
 	// = 0x00 0x01, 0x01, 0x00 0x01, 0x01, 0x01, 0x00 0x01, 0x01, 0x00 0x01, ...
 	rle1 := []byte{
@@ -49,20 +49,20 @@ func main() {
 	buf.Write(rle1)
 
 	// Indexed image 2: 2x2 simple image
-	binary.Write(&buf, binary.LittleEndian, uint16(2))     // width
-	binary.Write(&buf, binary.LittleEndian, uint16(2))     // height
-	rle2 := []byte{0x01, 0x02, 0x03, 0x04}                 // 4 palette indices (no zeros = no RLE)
+	binary.Write(&buf, binary.LittleEndian, uint16(2)) // width
+	binary.Write(&buf, binary.LittleEndian, uint16(2)) // height
+	rle2 := []byte{0x01, 0x02, 0x03, 0x04}             // 4 palette indices (no zeros = no RLE)
 	binary.Write(&buf, binary.LittleEndian, uint16(len(rle2)))
 	buf.Write(rle2)
 
 	// True-color image: 2x2 RGBA
-	binary.Write(&buf, binary.LittleEndian, uint16(2))     // width
-	binary.Write(&buf, binary.LittleEndian, uint16(2))     // height
+	binary.Write(&buf, binary.LittleEndian, uint16(2)) // width
+	binary.Write(&buf, binary.LittleEndian, uint16(2)) // height
 	// ABGR pixels: Red, Green, Blue, White
 	buf.Write([]byte{
-		255, 0, 0, 255,     // ABGR -> Red (A=255, B=0, G=0, R=255)
-		255, 0, 255, 0,     // ABGR -> Green (A=255, B=0, G=255, R=0)
-		255, 255, 0, 0,     // ABGR -> Blue (A=255, B=255, G=0, R=0)
+		255, 0, 0, 255, // ABGR -> Red (A=255, B=0, G=0, R=255)
+		255, 0, 255, 0, // ABGR -> Green (A=255, B=0, G=255, R=0)
+		255, 255, 0, 0, // ABGR -> Blue (A=255, B=255, G=0, R=0)
 		255, 255, 255, 255, // ABGR -> White (A=255, B=255, G=255, R=255)
 	})
 


### PR DESCRIPTION
## Summary

CI on `main` has been failing since 2026-02-05 (when PR #47 merged). 39 lint issues + 1 stale-offset test bug. This PR clears all of them so subsequent MVP-track PRs (#50–#55, blocked behind RFC #49) get trustworthy CI signal.

No semantic runtime changes — every fix is either formatting, ignoring an intentionally-discarded error, removing dead code, or correcting a test that drifted from the code it tests.

## Fix breakdown

| Category | Count | Approach |
|---|---|---|
| `gofmt` | 22 files | `gofmt -w ./...` (struct alignment + whitespace) |
| `errcheck` | 14 | `_ =` for intentional discards (SDL setup, packet sends, heap type assertions, `SetReadDeadline`) |
| `staticcheck` | 8 | Removed empty branches in `charselect_ui.go` (always-disabled Create/Delete buttons) and `entity.go` Update; replaced manual `.gat` strips with `strings.TrimSuffix`; dropped redundant `nil ||` before `len()`; fixed `NewContext` doc comment |
| `unconvert` | 3 | Dropped redundant `uint32()` casts in `packets.go` (`readU32` already returns `uint32`) |
| `misspell` | 1 | `//nolint:misspell` on "Gryphon" — RO-specific Royal Guard mount name |
| `unparam` | 1 | Simplified `mockGAT(width, height, blocked)` → `mockGAT(size, blocked)` (all tests use square grids) |
| Test bug | 1 | `TestCharInfoDecode` offsets corrected: Name 80→108, Slot 110→138 to match the eAthena layout the decoder uses |

## Test plan

- [x] `gofmt -l .` clean (no remaining unformatted files outside `testdata/`)
- [x] `go test ./internal/network/packets/... ./internal/game/world/... ./pkg/...` passes locally
- [ ] CI Lint job passes (was failing on main)
- [ ] CI Test job passes (was failing on main)
- [ ] CI Build job passes (was already passing)

CGO-dependent packages (engine, game/states, ui) couldn't be exercised locally without `pkg-config`/SDL2 — CI has them.

## Why now

This is a pure cleanup PR — no scope expansion. Required to unblock the RFC #49 MVP tracks: green `main` is a prerequisite for trusting CI signal on every subsequent track-A-through-F PR.

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)