### PR TITLE
feat(playerrender): port grfbrowser PlayMode procedural billboard

### DIFF
--- a/internal/engine/playerrender/playerrender.go
+++ b/internal/engine/playerrender/playerrender.go
@@ -5,7 +5,7 @@
 // rendering — the working reference Boris confirmed visually before. We
 // own our own GL state (program, VAO, texture) rather than going through
 // scene.SpriteRenderer. The shader source is shared with scene's sprite
-// renderer (same vertex layout, same uniforms) so behaviour matches.
+// renderer (same vertex layout, same uniforms) so behavior matches.
 //
 // Today the texture is procedural (a small humanoid colored quad). The
 // next PR replaces it with real Novice SPR/ACT composites loaded from the

--- a/internal/engine/playerrender/playerrender.go
+++ b/internal/engine/playerrender/playerrender.go
@@ -1,0 +1,170 @@
+// Package playerrender renders the local player character as a billboard
+// inside the 3D scene framebuffer.
+//
+// This is a faithful port of cmd/grfbrowser/map_viewer.go's PlayMode
+// rendering — the working reference Boris confirmed visually before. We
+// own our own GL state (program, VAO, texture) rather than going through
+// scene.SpriteRenderer. The shader source is shared with scene's sprite
+// renderer (same vertex layout, same uniforms) so behaviour matches.
+//
+// Today the texture is procedural (a small humanoid colored quad). The
+// next PR replaces it with real Novice SPR/ACT composites loaded from the
+// GRF.
+package playerrender
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/go-gl/gl/v4.1-core/gl"
+
+	"github.com/Faultbox/midgard-ro/internal/engine/character"
+	"github.com/Faultbox/midgard-ro/internal/engine/scene/shaders"
+	"github.com/Faultbox/midgard-ro/internal/engine/shader"
+	"github.com/Faultbox/midgard-ro/internal/engine/sprite"
+	"github.com/Faultbox/midgard-ro/internal/game/entity"
+	"github.com/Faultbox/midgard-ro/pkg/math"
+)
+
+// Renderer owns the GL state for drawing the local player as a billboard.
+type Renderer struct {
+	// Shader program + uniform locations (mirror scene.SpriteRenderer's setup,
+	// kept independent so we can render with our own VAO/draw pattern).
+	program       uint32
+	locViewProj   int32
+	locWorldPos   int32
+	locSpriteSize int32
+	locCamRight   int32
+	locCamUp      int32
+	locTexture    int32
+	locTint       int32
+
+	// Billboard quad — 4 verts, drawn as TRIANGLE_STRIP (matches grfbrowser).
+	vao uint32
+	vbo uint32
+
+	// Procedural humanoid texture.
+	texture       uint32
+	width, height int
+
+	// Scale applied to (texturePixelsW, texturePixelsH) to get world units.
+	scale float32
+}
+
+// New creates a renderer with a procedural humanoid texture.
+// Must be called on the GL thread (creates shader program + VAO + texture).
+func New() (*Renderer, error) {
+	r := &Renderer{
+		scale: sprite.DefaultProceduralScale,
+	}
+
+	// Compile sprite shader (same source scene.SpriteRenderer uses).
+	prog, err := shader.CompileProgram(shaders.SpriteVertexShader, shaders.SpriteFragmentShader)
+	if err != nil {
+		return nil, fmt.Errorf("sprite shader: %w", err)
+	}
+	r.program = prog
+	r.locViewProj = shader.GetUniform(prog, "uViewProj")
+	r.locWorldPos = shader.GetUniform(prog, "uWorldPos")
+	r.locSpriteSize = shader.GetUniform(prog, "uSpriteSize")
+	r.locCamRight = shader.GetUniform(prog, "uCamRight")
+	r.locCamUp = shader.GetUniform(prog, "uCamUp")
+	r.locTexture = shader.GetUniform(prog, "uTexture")
+	r.locTint = shader.GetUniform(prog, "uTint")
+
+	// VAO/VBO. Vertex layout matches grfbrowser exactly:
+	// foot-anchored quad (Y=0 at feet, Y=1 at head), TRIANGLE_STRIP order.
+	gl.GenVertexArrays(1, &r.vao)
+	gl.GenBuffers(1, &r.vbo)
+	gl.BindVertexArray(r.vao)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.vbo)
+
+	verts := sprite.GenerateBillboardQuadVertices() // [TL, TR, BL, BR] × (pos, uv)
+	gl.BufferData(gl.ARRAY_BUFFER, len(verts)*4, unsafe.Pointer(&verts[0]), gl.STATIC_DRAW)
+
+	// position (location 0): vec2
+	gl.VertexAttribPointerWithOffset(0, 2, gl.FLOAT, false, 4*4, 0)
+	gl.EnableVertexAttribArray(0)
+	// texcoord (location 1): vec2
+	gl.VertexAttribPointerWithOffset(1, 2, gl.FLOAT, false, 4*4, 2*4)
+	gl.EnableVertexAttribArray(1)
+
+	gl.BindVertexArray(0)
+
+	// Procedural texture.
+	r.width = sprite.DefaultProceduralWidth
+	r.height = sprite.DefaultProceduralHeight
+	pixels := sprite.GenerateProceduralPlayer(r.width, r.height)
+
+	gl.GenTextures(1, &r.texture)
+	gl.BindTexture(gl.TEXTURE_2D, r.texture)
+	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, int32(r.width), int32(r.height), 0,
+		gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(pixels))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+	gl.BindTexture(gl.TEXTURE_2D, 0)
+
+	return r, nil
+}
+
+// Render draws the player billboard at the character's render position.
+// camPosX/Z are the camera world XZ — used to orient the billboard.
+//
+// Mirrors cmd/grfbrowser/map_viewer.go renderPlayerCharacter (procedural
+// path) including draw mode + state transitions.
+func (r *Renderer) Render(viewProj math.Mat4, char *entity.Character, camPosX, camPosZ float32) {
+	if r == nil || char == nil || r.program == 0 || r.vao == 0 || r.texture == 0 {
+		return
+	}
+
+	right, up := character.BillboardVectors(camPosX, camPosZ, char.RenderX, char.RenderZ)
+
+	spriteW := float32(r.width) * r.scale
+	spriteH := float32(r.height) * r.scale
+
+	gl.Enable(gl.BLEND)
+	gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+	gl.UseProgram(r.program)
+
+	gl.UniformMatrix4fv(r.locViewProj, 1, false, &viewProj[0])
+	gl.Uniform3f(r.locWorldPos, char.RenderX, char.RenderY, char.RenderZ)
+	gl.Uniform2f(r.locSpriteSize, spriteW, spriteH)
+	gl.Uniform4f(r.locTint, 1.0, 1.0, 1.0, 1.0)
+	gl.Uniform3f(r.locCamRight, right[0], right[1], right[2])
+	gl.Uniform3f(r.locCamUp, up[0], up[1], up[2])
+
+	gl.ActiveTexture(gl.TEXTURE0)
+	gl.BindTexture(gl.TEXTURE_2D, r.texture)
+	gl.Uniform1i(r.locTexture, 0)
+
+	gl.BindVertexArray(r.vao)
+	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
+	gl.BindVertexArray(0)
+
+	gl.Disable(gl.BLEND)
+}
+
+// Destroy releases all GL resources owned by the renderer.
+func (r *Renderer) Destroy() {
+	if r == nil {
+		return
+	}
+	if r.texture != 0 {
+		gl.DeleteTextures(1, &r.texture)
+		r.texture = 0
+	}
+	if r.vbo != 0 {
+		gl.DeleteBuffers(1, &r.vbo)
+		r.vbo = 0
+	}
+	if r.vao != 0 {
+		gl.DeleteVertexArrays(1, &r.vao)
+		r.vao = 0
+	}
+	if r.program != 0 {
+		gl.DeleteProgram(r.program)
+		r.program = 0
+	}
+}

--- a/internal/game/states/ingame.go
+++ b/internal/game/states/ingame.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/Faultbox/midgard-ro/internal/engine/camera"
 	"github.com/Faultbox/midgard-ro/internal/engine/picking"
+	"github.com/Faultbox/midgard-ro/internal/engine/playerrender"
 	"github.com/Faultbox/midgard-ro/internal/engine/scene"
 	"github.com/Faultbox/midgard-ro/internal/game/entity"
 	"github.com/Faultbox/midgard-ro/internal/logger"
 	"github.com/Faultbox/midgard-ro/internal/network"
 	"github.com/Faultbox/midgard-ro/internal/network/packets"
 	"github.com/Faultbox/midgard-ro/pkg/formats"
+	"github.com/Faultbox/midgard-ro/pkg/math"
 )
 
 // InGameStateConfig contains configuration for the in-game state.
@@ -35,9 +37,10 @@ type InGameState struct {
 	manager *Manager
 
 	// Rendering
-	scene  *scene.Scene
-	camera *camera.ThirdPersonCamera
-	gat    *formats.GAT // Walkability + minimap shape
+	scene        *scene.Scene
+	camera       *camera.ThirdPersonCamera
+	gat          *formats.GAT // Walkability + minimap shape
+	playerRender *playerrender.Renderer
 
 	// Entities
 	entityManager *entity.Manager
@@ -142,6 +145,14 @@ func (s *InGameState) Enter() error {
 	s.camera.Distance = 145 // RO-style close distance (like grfbrowser PlayMode)
 	s.camera.Yaw = 0
 
+	// Build the player billboard renderer (procedural texture for now —
+	// real Novice SPR/ACT composites land in a follow-up PR).
+	if pr, prErr := playerrender.New(); prErr != nil {
+		logger.Warn("failed to create player renderer", zap.Error(prErr))
+	} else {
+		s.playerRender = pr
+	}
+
 	s.StatusMsg = fmt.Sprintf("Entered %s", s.MapName)
 
 	// Mark entry time — used as the local epoch for ClientTick and as the
@@ -215,6 +226,10 @@ func (s *InGameState) loadMap() error {
 
 // Exit is called when leaving this state.
 func (s *InGameState) Exit() error {
+	if s.playerRender != nil {
+		s.playerRender.Destroy()
+		s.playerRender = nil
+	}
 	if s.scene != nil {
 		s.scene.Destroy()
 		s.scene = nil
@@ -265,14 +280,20 @@ func (s *InGameState) Update(dt float64) error {
 
 // Render is called every frame to draw the state.
 func (s *InGameState) Render() error {
-	// Render 3D scene if available. Player billboard rendering is parked
-	// here pending a faithful port of the working grfbrowser PlayMode
-	// path (RFC #49 Track B follow-up) — the speculative procedural
-	// billboard was reverted because integration was non-trivial.
-	if s.scene != nil && s.camera != nil && s.SceneReady && s.player != nil {
-		x, y, z := s.player.RenderPosition()
-		s.scene.RenderWithThirdPerson(s.camera, x, y, z)
+	if s.scene == nil || s.camera == nil || !s.SceneReady || s.player == nil {
+		return nil
 	}
+
+	// Player position for the camera to follow.
+	x, y, z := s.player.RenderPosition()
+
+	// Use the extras hook so the player billboard composites into the
+	// scene framebuffer (after world rendering, before unbind).
+	s.scene.RenderWithThirdPersonExtras(s.camera, x, y, z, func(viewProj math.Mat4) {
+		if s.playerRender != nil {
+			s.playerRender.Render(viewProj, s.player, s.camera.PosX, s.camera.PosZ)
+		}
+	})
 	return nil
 }
 


### PR DESCRIPTION
## Summary

**Step 3 of Option C** (the faithful PlayMode port). First slice: procedural billboard that compiles & wires through the engine. Real Novice SPR/ACT composites + animation land in a follow-up.

This is a verbatim port from `cmd/grfbrowser/map_viewer.go` — the working reference Boris confirmed visually. The previous attempt (PR #59 reverted in commit f37be5b) routed through `scene.SpriteRenderer` and was invisible despite valid GL params and zero GL errors. Rather than chase what was different, this PR duplicates grfbrowser's exact ownership pattern.

## What changed

- **New package `internal/engine/playerrender`** — a `Renderer` type owning its own:
  - shader program (compiled from scene's embedded sprite shaders)
  - 4-vert TRIANGLE_STRIP VAO using `sprite.GenerateBillboardQuadVertices`
  - procedural humanoid texture
- `Scene.RenderWithThirdPersonExtras` / `RenderWithViewExtras` — callback hook that runs *inside* the FBO between water render and unbind, so the player billboard composites into the scene texture
- `Scene.LastViewProj()` — accessor (will be needed by 3D-click ray-cast in PR #59)
- `InGameState` owns a `*playerrender.Renderer`, creates it after camera setup in `Enter()`, tears it down in `Exit()`, and the render callback draws the player

## Why duplicate instead of reuse SpriteRenderer

`scene.SpriteRenderer` uses a 6-vertex `gl.TRIANGLES` VAO; grfbrowser uses 4-vertex `gl.TRIANGLE_STRIP`. Both produce the same quad geometrically, but the previous attempt routed through SpriteRenderer and produced no visible output despite identical-looking params. Rather than spend more cycles diffing GL state machines, this PR commits to grfbrowser's exact pattern. SpriteRenderer is left untouched — it can stay around for non-player sprites later.

## What's still missing (next PR)

- Real Novice SPR/ACT body + head loading from GRF
- Composite frame building (head + body anchored merge)
- Direction-aware sprite frame selection (8-way)
- Walking-cycle animation timing
- Shadow ellipse under the player

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/network/packets/... ./internal/game/world/...` passes
- [ ] Launch client → log in → enter Prontera → see a humanoid colored billboard at the spawn point
- [ ] Click in the world → character walks (3D click works with PR #59 stack; minimap-only with this branch alone)

## Stacking note

This branch is off `main`. PR #59 (walk packets) and PR #60 (F3 overlay) are also off main but unmerged. Either can land first; minor conflict in `internal/engine/scene/scene.go` (LastViewProj already added by #59 — git will resolve cleanly with `theirs`).

Refs #49, #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)