### PR TITLE
fix(scene): glFlush after extras so writes commit before imgui samples

### DIFF
--- a/internal/engine/scene/scene.go
+++ b/internal/engine/scene/scene.go
@@ -403,6 +403,19 @@ func (s *Scene) RenderWithViewExtras(view math.Mat4, extras func(viewProj math.M
 		extras(viewProj)
 	}
 
+	// Force a GL flush before returning so that any writes made by world
+	// renderers OR by the extras callback are committed to the FBO's
+	// color texture before the imgui display step samples it.
+	//
+	// On macOS, OpenGL is layered on Metal which is deferred/tiled. Our
+	// FBO writes can sit in a command queue past the end of this function
+	// and not be visible when imgui samples the texture in the same
+	// frame — the symptom is the texture appearing to contain pre-write
+	// content (the world without the extras' contribution). Verified
+	// empirically: a sprite render in extras was invisible until we
+	// added a flush; with it the sprite shows correctly.
+	gl.Flush()
+
 	return s.framebuffer.ColorTexture()
 }
 
@@ -437,6 +450,15 @@ func (s *Scene) RenderSprite(viewProj math.Mat4, camRight, camUp math.Vec3, worl
 // Used by the debug overlay.
 func (s *Scene) FramebufferSize() (width, height int32) {
 	return s.config.Width, s.config.Height
+}
+
+// FramebufferID returns the underlying GL framebuffer object ID.
+// Used by diagnostics to verify the correct FB is bound.
+func (s *Scene) FramebufferID() uint32 {
+	if s.framebuffer == nil {
+		return 0
+	}
+	return s.framebuffer.FBO()
 }
 
 // Resize updates the scene dimensions.


### PR DESCRIPTION
## Summary

Single-line fix to make the procedural player billboard (PR #61) actually visible. The whole stalemate from this evening turns out to be macOS-specific: Apple's OpenGL is layered on Metal which is deferred/tiled, so writes made inside the extras callback can sit in a command queue past the end of the render function and not be visible when imgui samples the FBO color texture in the same frame.

## How we found it

Step-by-step diagnostic instrumentation (after deciding to invest in tooling instead of guessing):

1. F3 overlay confirmed sane player/camera/scene values, GL Err: NONE
2. Magenta-clear test inside extras: screen still showed normal world (writes invisible)
3. FBO check inside extras: `sceneFBO=1, currentFBO=1, match=true` — bind was correct
4. Pixel readback right after our clear: `R=255 G=0 B=255 A=255` — magenta IS in the FBO
5. Render-call counter: 41/sec = 41 FPS — Render not called twice
6. `gl.Finish()` at end of extras: **MAGENTA + procedural sprite both appear** — confirmed deferred-commit

## The fix

A single `gl.Flush()` at the end of `Scene.RenderWithViewExtras` (lighter than `gl.Finish()` which blocks). This forces all queued GL commands (both world renderers' AND the extras callback's) to the GPU before the function returns, so the texture imgui samples contains the full composite.

## Validated

Boris confirmed visually: procedural humanoid (head/body/legs in blue tones, exactly the `sprite.GenerateProceduralPlayer` output) is now visible at the player's position over Prontera buildings + cobblestones. Click-to-walk follows the cursor.

## Test plan

- [x] `go build ./...` clean
- [x] Visual confirmation in Prontera against the local rAthena stack — sprite visible, world rendered correctly, no magenta
- [ ] CI green

Refs #49, #51, #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)