### PR TITLE
feat(ui): switch active UI backend to ui2d (RFC #67 Phase 1)

### DIFF
--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/Faultbox/midgard-ro/pkg/encoding"
 	"github.com/Faultbox/midgard-ro/pkg/grf"
 )
 
@@ -38,6 +39,13 @@ func (m *Manager) AddArchive(path string) error {
 }
 
 // Load loads a file from the archives.
+//
+// Path encoding: GRFs store Korean folder/file names as raw EUC-KR bytes (the
+// original Windows clients are CP949). Go source uses UTF-8, so a literal like
+// `data\texture\유저인터페이스\…` won't match the on-disk entry as-is. We try
+// the path verbatim first (for ASCII-only paths and any caller that already
+// pre-encoded), and only fall back to UTF-8→EUC-KR if that misses. The cache
+// is keyed by the original path so callers don't need to think about it.
 func (m *Manager) Load(path string) ([]byte, error) {
 	// Check cache first
 	if data, ok := m.cache.Get(path); ok {
@@ -53,6 +61,16 @@ func (m *Manager) Load(path string) ([]byte, error) {
 		if err == nil {
 			m.cache.Set(path, data)
 			return data, nil
+		}
+	}
+
+	if encoded := string(encoding.UTF8ToEUCKR(path)); encoded != path {
+		for i := len(m.archives) - 1; i >= 0; i-- {
+			data, err := m.archives[i].Read(encoded)
+			if err == nil {
+				m.cache.Set(path, data)
+				return data, nil
+			}
 		}
 	}
 

--- a/internal/engine/ui2d/color.go
+++ b/internal/engine/ui2d/color.go
@@ -25,8 +25,11 @@ var (
 	ColorButtonActive = Color{0.1, 0.3, 0.5, 1}
 	ColorInputBg      = Color{0.05, 0.05, 0.08, 1}
 	ColorInputBorder  = Color{0.2, 0.2, 0.3, 1}
-	ColorText         = Color{0.9, 0.9, 0.9, 1}
-	ColorTextDim      = Color{0.5, 0.5, 0.6, 1}
+	// ColorText is the default text color, tuned for legibility on the cream
+	// win_msgbox.bmp body (which is the dominant text surface).
+	ColorText        = Color{0.1, 0.1, 0.15, 1}
+	ColorTextOnDark  = Color{0.9, 0.9, 0.9, 1}
+	ColorTextDim     = Color{0.4, 0.4, 0.5, 1}
 	ColorHighlight    = Color{0.2, 0.6, 0.9, 1}
 )
 

--- a/internal/engine/ui2d/color.go
+++ b/internal/engine/ui2d/color.go
@@ -27,10 +27,10 @@ var (
 	ColorInputBorder  = Color{0.2, 0.2, 0.3, 1}
 	// ColorText is the default text color, tuned for legibility on the cream
 	// win_msgbox.bmp body (which is the dominant text surface).
-	ColorText        = Color{0.1, 0.1, 0.15, 1}
-	ColorTextOnDark  = Color{0.9, 0.9, 0.9, 1}
-	ColorTextDim     = Color{0.4, 0.4, 0.5, 1}
-	ColorHighlight    = Color{0.2, 0.6, 0.9, 1}
+	ColorText       = Color{0.1, 0.1, 0.15, 1}
+	ColorTextOnDark = Color{0.9, 0.9, 0.9, 1}
+	ColorTextDim    = Color{0.4, 0.4, 0.5, 1}
+	ColorHighlight  = Color{0.2, 0.6, 0.9, 1}
 )
 
 // RGBA creates a color from 8-bit RGBA values (0-255).

--- a/internal/engine/ui2d/context.go
+++ b/internal/engine/ui2d/context.go
@@ -31,12 +31,14 @@ type Context struct {
 
 // WindowState holds state for a UI window.
 type WindowState struct {
-	ID     string
-	X, Y   float32
-	W, H   float32
-	Open   bool
-	Moving bool
-	Skin   *NineSlice // Per-window skin override (nil uses default)
+	ID      string
+	X, Y    float32
+	W, H    float32
+	Open    bool
+	Moving  bool
+	Dragged bool       // True once the user has dragged this window — caller
+	                   // x/y are then treated as initial-only and ignored.
+	Skin    *NineSlice // Per-window skin override (nil uses default)
 }
 
 // NewContext creates a new UI context.
@@ -108,10 +110,13 @@ func (c *Context) BeginWindow(id string, x, y, w, h float32, title string) bool 
 		}
 		c.windows[id] = ws
 	} else {
-		// Always update size from parameters (position only when not moving)
+		// Always update size from parameters. Position parameters are only an
+		// initial hint: once the user drags the window we stop overwriting
+		// X/Y so the new position survives drop. Without this the window
+		// snaps back to the caller's center-of-screen each frame.
 		ws.W = w
 		ws.H = h
-		if !ws.Moving {
+		if !ws.Moving && !ws.Dragged {
 			ws.X = x
 			ws.Y = y
 		}
@@ -135,6 +140,7 @@ func (c *Context) BeginWindow(id string, x, y, w, h float32, title string) bool 
 	if ws.Moving && c.input.MouseLeftDown {
 		ws.X += c.input.MouseDeltaX
 		ws.Y += c.input.MouseDeltaY
+		ws.Dragged = true
 	}
 
 	if c.input.MouseLeftReleased {
@@ -153,18 +159,17 @@ func (c *Context) BeginWindow(id string, x, y, w, h float32, title string) bool 
 		skin.Draw(c.renderer, ws.X, ws.Y, ws.W, ws.H, ColorWhite)
 	} else {
 		c.renderer.DrawPanel(ws.X, ws.Y, ws.W, ws.H, ColorPanelBg, ColorPanelBorder)
-	}
 
-	// Draw title bar (solid color fallback only when no skin)
-	if skin == nil {
+		// Draw title bar + title only in the skinless fallback. The GRF
+		// skin (win_msgbox.bmp) bakes its own "메세지" title bar, so we
+		// don't draw a competing one — that produced the overlap Boris
+		// saw on first render.
 		c.renderer.DrawRect(ws.X+1, ws.Y+1, ws.W-2, titleBarH-1, ColorButtonNormal)
+		scale := float32(2.0)
+		_, textH := c.renderer.MeasureText(title, scale)
+		textY := ws.Y + (titleBarH-textH)/2
+		c.renderer.DrawText(ws.X+8, textY, title, scale, ColorText)
 	}
-
-	// Draw title text
-	scale := float32(2.0)
-	_, textH := c.renderer.MeasureText(title, scale)
-	textY := ws.Y + (titleBarH-textH)/2
-	c.renderer.DrawText(ws.X+8, textY, title, scale, ColorText)
 
 	// Set cursor for content (below title bar, with padding)
 	c.cursorX = ws.X + 8

--- a/internal/engine/ui2d/context.go
+++ b/internal/engine/ui2d/context.go
@@ -30,14 +30,17 @@ type Context struct {
 }
 
 // WindowState holds state for a UI window.
+//
+// Dragged becomes true the first time the user moves the window; once set,
+// the caller's x/y arguments to BeginWindow are treated as initial-only and
+// ignored, so the new position survives across frames.
 type WindowState struct {
 	ID      string
 	X, Y    float32
 	W, H    float32
 	Open    bool
 	Moving  bool
-	Dragged bool       // True once the user has dragged this window — caller
-	                   // x/y are then treated as initial-only and ignored.
+	Dragged bool
 	Skin    *NineSlice // Per-window skin override (nil uses default)
 }
 

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -143,8 +143,14 @@ func New(cfg *config.Config) (*Game, error) {
 		return nil, err
 	}
 
-	// Create UI backend (ImGui by default for backward compatibility)
-	g.uiBackend = ui.NewImGuiBackend()
+	// Create UI backend. We swapped from ImGui to the custom ui2d renderer
+	// (see RFC #67) — ImGui stays only as the SDL/GL windowing host.
+	ui2dBackend, err := ui.NewUI2DBackend(cfg.Graphics.Width, cfg.Graphics.Height)
+	if err != nil {
+		return nil, fmt.Errorf("create ui2d backend: %w", err)
+	}
+	ui2dBackend.SetAssetLoader(g.assetManager.Load)
+	g.uiBackend = ui2dBackend
 
 	logger.Info("game initialized successfully")
 	return g, nil

--- a/internal/game/ui/ui2d_backend.go
+++ b/internal/game/ui/ui2d_backend.go
@@ -4,6 +4,9 @@ package ui
 import (
 	"fmt"
 
+	"github.com/AllenDang/cimgui-go/imgui"
+	"github.com/go-gl/gl/v4.1-core/gl"
+
 	"github.com/Faultbox/midgard-ro/internal/engine/ui2d"
 )
 
@@ -39,8 +42,77 @@ func NewUI2DBackend(width, height int) (*UI2DBackend, error) {
 }
 
 // Begin starts a new UI frame.
+//
+// We piggyback on cimgui-go's SDL backend for windowing and input. ImGui has
+// already pumped SDL events into its IO by this point, so we read the mouse
+// and key state straight off ImGui's IO rather than installing a parallel SDL
+// event handler. Same trick the ImGuiBackend uses (see updateInputFromImGui).
 func (b *UI2DBackend) Begin() {
+	b.syncInputFromImGui()
+	b.syncViewportSize()
+	b.fixHiDPIViewport()
 	b.ctx.Begin()
+}
+
+// fixHiDPIViewport overrides the glViewport that cimgui-go's SDL backend set
+// to (0, 0, DisplaySize.x, DisplaySize.y). Those numbers are in logical
+// points, but glViewport interprets them as framebuffer pixels — on a 2x
+// retina display that confines our drawing to the bottom-left quadrant of the
+// real framebuffer. Setting the viewport to the drawable size
+// (points × DisplayFramebufferScale) makes our point-space rendering land
+// 1:1 under the OS cursor.
+func (b *UI2DBackend) fixHiDPIViewport() {
+	io := imgui.CurrentIO()
+	disp := io.DisplaySize()
+	scale := io.DisplayFramebufferScale()
+	if scale.X <= 0 {
+		scale.X = 1
+	}
+	if scale.Y <= 0 {
+		scale.Y = 1
+	}
+	gl.Viewport(0, 0, int32(disp.X*scale.X), int32(disp.Y*scale.Y))
+}
+
+// syncInputFromImGui copies the current frame's mouse + key state from ImGui's
+// IO into the ui2d InputState. Must run before ctx.Begin() (which calls
+// InputState.Update for edge detection).
+//
+// Coordinate space: empirically (via the click-corner test) cimgui-go's SDL
+// backend reports mouse position in *global screen* points, not relative to
+// the SDL window. Click deltas across known widget widths matched our render
+// units 1:1, so the only correction needed is subtracting the SDL window's
+// screen position — given to us by MainViewport().Pos(). After that the
+// mouse lives in the same logical 0..DisplaySize space we render into,
+// which fixHiDPIViewport stretches across the full retina framebuffer.
+func (b *UI2DBackend) syncInputFromImGui() {
+	in := b.ctx.Input()
+	io := imgui.CurrentIO()
+
+	winPos := imgui.MainViewport().Pos()
+	mp := imgui.MousePos()
+	in.MouseX = mp.X - winPos.X
+	in.MouseY = mp.Y - winPos.Y
+	in.MouseLeftDown = imgui.IsMouseDown(imgui.MouseButtonLeft)
+	in.MouseRightDown = imgui.IsMouseDown(imgui.MouseButtonRight)
+	in.MouseMiddleDown = imgui.IsMouseDown(imgui.MouseButtonMiddle)
+	in.ScrollX = io.MouseWheelH()
+	in.ScrollY = io.MouseWheel()
+
+	in.KeyBackspace = imgui.IsKeyDown(imgui.KeyBackspace)
+	in.KeyEnter = imgui.IsKeyDown(imgui.KeyEnter)
+	in.KeyEscape = imgui.IsKeyDown(imgui.KeyEscape)
+	in.KeyTab = imgui.IsKeyDown(imgui.KeyTab)
+}
+
+// syncViewportSize keeps the ui2d renderer matched to ImGui's viewport size,
+// so the UI scales correctly when the SDL window is resized.
+func (b *UI2DBackend) syncViewportSize() {
+	size := imgui.MainViewport().Size()
+	curW, curH := b.ctx.GetScreenSize()
+	if int(size.X) != int(curW) || int(size.Y) != int(curH) {
+		b.ctx.Resize(int(size.X), int(size.Y))
+	}
 }
 
 // End finishes the UI frame.
@@ -402,11 +474,11 @@ func (b *UI2DBackend) RenderInGameUI(state InGameUIState, dt float64, width, hei
 	scale := float32(2.0)
 	barY := height - 25
 	b.ctx.Renderer().DrawRect(0, barY, width, 25, ui2d.ColorPanelBg)
-	b.ctx.Renderer().DrawText(10, barY+4, statusText, scale, ui2d.ColorText)
+	b.ctx.Renderer().DrawText(10, barY+4, statusText, scale, ui2d.ColorTextOnDark)
 
 	posText := fmt.Sprintf("(%d, %d)", state.PlayerTileX, state.PlayerTileY)
 	posW, _ := b.ctx.Renderer().MeasureText(posText, scale)
-	b.ctx.Renderer().DrawText(width-posW-10, barY+4, posText, scale, ui2d.ColorText)
+	b.ctx.Renderer().DrawText(width-posW-10, barY+4, posText, scale, ui2d.ColorTextOnDark)
 }
 
 // RenderFPSOverlay renders an FPS counter.
@@ -420,7 +492,7 @@ func (b *UI2DBackend) RenderFPSOverlay(fps float64, width, height float32) {
 
 	// Semi-transparent background
 	b.ctx.Renderer().DrawRect(x-5, y-2, textW+10, 20, ui2d.ColorPanelBg.WithAlpha(0.5))
-	b.ctx.Renderer().DrawText(x, y, text, scale, ui2d.ColorText)
+	b.ctx.Renderer().DrawText(x, y, text, scale, ui2d.ColorTextOnDark)
 }
 
 // RenderScreenshotMessage renders a screenshot notification.

--- a/internal/game/ui/window_skin.go
+++ b/internal/game/ui/window_skin.go
@@ -11,28 +11,32 @@ type WindowSkin struct {
 	Frame *ui2d.NineSlice
 }
 
-// RO UI texture base path (Korean folder name for "user interface")
-const skinBasePath = `data\texture\유저인터페이스\basic_interface\`
+// RO UI texture base path (Korean folder name for "user interface").
+// Note: there is no `basic_interface\` subfolder for win_msgbox — the file
+// sits directly under 유저인터페이스. Other UI assets (login_interface, etc.)
+// do live in subfolders. EUC-KR encoding is handled by assets.Manager.Load.
+const skinBasePath = `data\texture\유저인터페이스\`
 
 // LoadWindowSkin loads the RO window frame skin from GRF textures.
 // Returns an error if the required textures are not available.
 func LoadWindowSkin(tc *TextureCache) (*WindowSkin, error) {
-	// RO uses a single window frame texture that works as a 9-slice
+	// RO uses a single 280×120 BMP that 9-slices into title bar (top),
+	// body, and footer bar (bottom). Insets measured visually:
+	// top includes the title bar with close icon; bottom is the thin footer.
 	framePath := skinBasePath + `win_msgbox.bmp`
 	info, err := tc.Load(framePath)
 	if err != nil {
 		return nil, fmt.Errorf("loading window frame skin: %w", err)
 	}
 
-	// Standard RO window frame border insets (pixels from edges)
 	frame := &ui2d.NineSlice{
 		TextureID: info.ID,
 		TexWidth:  info.Width,
 		TexHeight: info.Height,
-		Left:      8,
-		Right:     8,
-		Top:       8,
-		Bottom:    8,
+		Left:      6,
+		Right:     6,
+		Top:       24,
+		Bottom:    12,
 	}
 
 	return &WindowSkin{Frame: frame}, nil


### PR DESCRIPTION
## Summary

- Switches the active in-game UI from ImGui to the custom `ui2d` renderer (per RFC #67). ImGui stays only as the SDL/GL windowing host.
- Login window now renders through the GRF `win_msgbox.bmp` 9-slice skin and is fully draggable; mouse hit-tests align with the OS cursor on retina displays.
- Fixes silent EUC-KR path lookup failures, a wrong skin path, and two HiDPI coordinate bugs surfaced while bringing the backend up.

## Commits

1. **fix(assets):** fall back to EUC-KR encoded path on GRF lookup miss — Korean folder names work without callers having to think about it.
2. **fix(ui/skin):** correct `win_msgbox.bmp` path (no `basic_interface/`) and tune 9-slice insets to 6/24/12/6 to match the actual title bar / footer in the texture.
3. **feat(ui2d):** add `WindowState.Dragged` so dropped windows stay where the user puts them; skip drawing our own title text when a skin is active (avoids overlap with the skin's baked-in "메세지"); flip `ColorText` to a near-black for readability on the cream skin and add `ColorTextOnDark` for the few callsites drawing on dark surfaces.
4. **feat(game):** swap `NewImGuiBackend()` for `NewUI2DBackend(...)` and wire `SetAssetLoader`. Adds `fixHiDPIViewport` (sets `glViewport` to drawable size each frame so point-space rendering covers the full retina framebuffer) and adjusts `syncInputFromImGui` to subtract `MainViewport().Pos()` from `MousePos` (cimgui-go's SDL backend reports mouse in global screen coords, not window-relative — confirmed empirically with the click-corner test).

## Out of scope (follow-ups after merge)

- Text input bridging — currently can't type into the username/password fields; credentials come from config.
- Login background BMP + logo — paths in `loadLoginTextures` still target nonexistent files.
- F3 debug overlay still uses ImGui (renders under the ui2d UI, harmless but ugly).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/game/ui/... ./internal/engine/ui2d/... ./internal/assets/...` pass
- [x] Manual: launch client, login window appears with GRF skin, drag the title bar — window stays where dropped after release.
- [x] Manual: click Login → connects to server → character select renders → "Enter Game" works → in Prontera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)