### PR TITLE
feat(ui2d): clean title bar so caller-supplied title shows

### DIFF
--- a/internal/engine/ui2d/context.go
+++ b/internal/engine/ui2d/context.go
@@ -159,18 +159,26 @@ func (c *Context) BeginWindow(id string, x, y, w, h float32, title string) bool 
 		skin = c.defaultSkin
 	}
 	if skin != nil {
+		// The GRF skin's optional clean title-strip overlay (see
+		// NineSlice.TitleStripSrcW) hides the BMP's baked-in "메세지"
+		// title and close icon, leaving us a blank title bar to stamp
+		// our own title text onto below.
 		skin.Draw(c.renderer, ws.X, ws.Y, ws.W, ws.H, ColorWhite)
 	} else {
 		c.renderer.DrawPanel(ws.X, ws.Y, ws.W, ws.H, ColorPanelBg, ColorPanelBorder)
-
-		// Draw title bar + title only in the skinless fallback. The GRF
-		// skin (win_msgbox.bmp) bakes its own "메세지" title bar, so we
-		// don't draw a competing one — that produced the overlap Boris
-		// saw on first render.
 		c.renderer.DrawRect(ws.X+1, ws.Y+1, ws.W-2, titleBarH-1, ColorButtonNormal)
+	}
+
+	// Draw the per-window title text on the title bar (always, regardless of
+	// skin — the skin's clean strip leaves room for it).
+	if title != "" {
 		scale := float32(2.0)
+		barH := titleBarH
+		if skin != nil && skin.Top > 0 {
+			barH = float32(skin.Top)
+		}
 		_, textH := c.renderer.MeasureText(title, scale)
-		textY := ws.Y + (titleBarH-textH)/2
+		textY := ws.Y + (barH-textH)/2
 		c.renderer.DrawText(ws.X+8, textY, title, scale, ColorText)
 	}
 

--- a/internal/engine/ui2d/nineslice.go
+++ b/internal/engine/ui2d/nineslice.go
@@ -11,6 +11,16 @@ type NineSlice struct {
 	Right  int
 	Top    int
 	Bottom int
+
+	// Optional clean title-strip overlay. When TitleStripSrcW > 0, after the
+	// standard 9-slice draws, a horizontal strip is overlaid across the top
+	// `Top` rows of the destination, sampled from source columns
+	// [TitleStripSrcX, TitleStripSrcX+TitleStripSrcW]. RO's win_msgbox bakes
+	// a "메세지" title and close icon into its title bar; sampling a clean
+	// gradient column from the right edge of the texture and stretching it
+	// across hides those pixels so callers can render their own title.
+	TitleStripSrcX int
+	TitleStripSrcW int
 }
 
 // Draw renders the nine-slice at the given screen position and size.
@@ -57,4 +67,10 @@ func (ns *NineSlice) Draw(r *Renderer, x, y, w, h float32, tint Color) {
 	r.DrawImageUV(ns.TextureID, x+l, y+t+midH, midW, b, uL, vB, uR, 1, tint)
 	// Bottom-right corner
 	r.DrawImageUV(ns.TextureID, x+l+midW, y+t+midH, ri, b, uR, vB, 1, 1, tint)
+
+	if ns.TitleStripSrcW > 0 && ns.Top > 0 {
+		u0 := float32(ns.TitleStripSrcX) / tw
+		u1 := float32(ns.TitleStripSrcX+ns.TitleStripSrcW) / tw
+		r.DrawImageUV(ns.TextureID, x, y, w, t, u0, 0, u1, vT, tint)
+	}
 }

--- a/internal/game/ui/window_skin.go
+++ b/internal/game/ui/window_skin.go
@@ -29,14 +29,20 @@ func LoadWindowSkin(tc *TextureCache) (*WindowSkin, error) {
 		return nil, fmt.Errorf("loading window frame skin: %w", err)
 	}
 
+	// Sample the rightmost 6px column of the title bar as the "clean strip"
+	// overlay — that region of win_msgbox.bmp is empty gradient (no text or
+	// icons), so stretching it across the whole title bar gives us a blank
+	// canvas to render our own title text on.
 	frame := &ui2d.NineSlice{
-		TextureID: info.ID,
-		TexWidth:  info.Width,
-		TexHeight: info.Height,
-		Left:      6,
-		Right:     6,
-		Top:       24,
-		Bottom:    12,
+		TextureID:      info.ID,
+		TexWidth:       info.Width,
+		TexHeight:      info.Height,
+		Left:           6,
+		Right:          6,
+		Top:            24,
+		Bottom:         12,
+		TitleStripSrcX: info.Width - 6,
+		TitleStripSrcW: 6,
 	}
 
 	return &WindowSkin{Frame: frame}, nil


### PR DESCRIPTION
## Summary

Polish step 1 from RFC #67 follow-up: kill the baked-in "메세지" title and close icon in `win_msgbox.bmp` so each window can show its own title text.

## Approach

Added an optional **clean-strip overlay** to `NineSlice`:

- New fields `TitleStripSrcX`, `TitleStripSrcW`. Zero values = no overlay (fully backwards compatible — existing 9-slice users unaffected).
- After the standard 9-slice draws, if `TitleStripSrcW > 0` we sample columns `[TitleStripSrcX, TitleStripSrcX+TitleStripSrcW]` of the source texture (rows `0..Top`) and stretch them across the destination's top `Top` rows. That covers whatever was baked into the original title bar.

For `win_msgbox.bmp` the loader points the strip at the rightmost 6px column — that region of the source is empty blue gradient with no text or icon, so stretching it across the title bar gives a blank canvas.

`BeginWindow` now renders the per-window title text on the title bar **always**, instead of skipping it under a skin. Visible text is now the caller-supplied title only ("Login to Ragnarok Online", "Connecting", etc.).

## Out of scope (next polish steps)

- Cream/bordered button styling (step 2)
- Real close `×` button on the right side (step 3)
- Better selection highlight (step 4)
- TTF font instead of the chunky bitmap font (later — Boris noted "feeling that we have low resolution" on the text)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/engine/ui2d/... ./internal/game/ui/...` pass
- [x] `gofmt` clean
- [x] Manual: launch client, login window title bar shows "Login to Ragnarok Online" in dark text on a clean blue gradient — no Korean text or close icon visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)