### PR TITLE
fix(ui2d): render solids over images + raised buttons

### DIFF
--- a/internal/engine/ui2d/color.go
+++ b/internal/engine/ui2d/color.go
@@ -18,11 +18,24 @@ var (
 	ColorBlue  = Color{0, 0, 1, 1}
 
 	// UI theme colors (RO-inspired)
-	ColorPanelBg      = Color{0.08, 0.08, 0.12, 0.75}
-	ColorPanelBorder  = Color{0.3, 0.3, 0.4, 1}
-	ColorButtonNormal = Color{0.15, 0.15, 0.2, 1}
-	ColorButtonHover  = Color{0.25, 0.25, 0.35, 1}
-	ColorButtonActive = Color{0.1, 0.3, 0.5, 1}
+	ColorPanelBg     = Color{0.08, 0.08, 0.12, 0.75}
+	ColorPanelBorder = Color{0.3, 0.3, 0.4, 1}
+	// Buttons: faint-gray fill that's distinguishable from the win_msgbox
+	// body (which is pure white, RGB 255). Hover tints the fill subtly blue
+	// to echo the RO title bar accent (rgb 53,93,204). Pressed deepens the
+	// blue. Border is mid-gray so it reads on the white surface. Reference:
+	// browser-default button look in the mannoeu/ragnarok-login recreation.
+	// Buttons read as raised 3D widgets on the pure-white BMP body via a
+	// classic Win95-style bevel. Fill is light gray (not near-white) so the
+	// white highlight registers against it; highlight on top/left, dark
+	// shadow on bottom/right. Border is the fallback outline if a caller
+	// renders without bevels. Hover/active tint blue (RO accent rgb 53,93,204).
+	ColorButtonNormal  = Color{0.84, 0.84, 0.86, 1}
+	ColorButtonHover   = Color{0.78, 0.84, 0.95, 1}
+	ColorButtonActive  = Color{0.55, 0.70, 0.90, 1}
+	ColorButtonBorder  = Color{0.40, 0.40, 0.45, 1}
+	ColorButtonBevelHi = Color{1.00, 1.00, 1.00, 1}
+	ColorButtonBevelLo = Color{0.30, 0.30, 0.35, 1}
 	ColorInputBg      = Color{0.05, 0.05, 0.08, 1}
 	ColorInputBorder  = Color{0.2, 0.2, 0.3, 1}
 	// ColorText is the default text color, tuned for legibility on the cream

--- a/internal/engine/ui2d/color.go
+++ b/internal/engine/ui2d/color.go
@@ -36,8 +36,8 @@ var (
 	ColorButtonBorder  = Color{0.40, 0.40, 0.45, 1}
 	ColorButtonBevelHi = Color{1.00, 1.00, 1.00, 1}
 	ColorButtonBevelLo = Color{0.30, 0.30, 0.35, 1}
-	ColorInputBg      = Color{0.05, 0.05, 0.08, 1}
-	ColorInputBorder  = Color{0.2, 0.2, 0.3, 1}
+	ColorInputBg       = Color{0.05, 0.05, 0.08, 1}
+	ColorInputBorder   = Color{0.2, 0.2, 0.3, 1}
 	// ColorText is the default text color, tuned for legibility on the cream
 	// win_msgbox.bmp body (which is the dominant text surface).
 	ColorText       = Color{0.1, 0.1, 0.15, 1}

--- a/internal/engine/ui2d/context.go
+++ b/internal/engine/ui2d/context.go
@@ -166,7 +166,9 @@ func (c *Context) BeginWindow(id string, x, y, w, h float32, title string) bool 
 		skin.Draw(c.renderer, ws.X, ws.Y, ws.W, ws.H, ColorWhite)
 	} else {
 		c.renderer.DrawPanel(ws.X, ws.Y, ws.W, ws.H, ColorPanelBg, ColorPanelBorder)
-		c.renderer.DrawRect(ws.X+1, ws.Y+1, ws.W-2, titleBarH-1, ColorButtonNormal)
+		// Skinless fallback: title bar uses the darker panel border color
+		// since ColorButtonNormal is now near-white (would look wrong here).
+		c.renderer.DrawRect(ws.X+1, ws.Y+1, ws.W-2, titleBarH-1, ColorPanelBorder)
 	}
 
 	// Draw the per-window title text on the title bar (always, regardless of
@@ -246,14 +248,26 @@ func (c *Context) Button(id string, width float32, label string) bool {
 
 	// Draw button
 	color := ColorButtonNormal
-	if c.activeWidget == fullID {
+	pressed := c.activeWidget == fullID
+	if pressed {
 		color = ColorButtonActive
 	} else if hovered {
 		color = ColorButtonHover
 	}
 
 	c.renderer.DrawRect(x, y, width, h, color)
-	c.renderer.DrawRectOutline(x, y, width, h, 1, ColorPanelBorder)
+	// Raised-button bevel: light highlight on top/left, dark shadow on
+	// bottom/right gives a 3D look that reads as a clickable widget on the
+	// pure-white BMP body. When pressed, swap the bevel direction so the
+	// button appears "pushed in".
+	hi, lo := ColorButtonBevelHi, ColorButtonBevelLo
+	if pressed {
+		hi, lo = ColorButtonBevelLo, ColorButtonBevelHi
+	}
+	c.renderer.DrawRect(x, y, width, 1, hi)     // top
+	c.renderer.DrawRect(x, y, 1, h, hi)         // left
+	c.renderer.DrawRect(x, y+h-1, width, 1, lo) // bottom
+	c.renderer.DrawRect(x+width-1, y, 1, h, lo) // right
 
 	// Draw button label centered
 	scale := float32(2.0)
@@ -660,7 +674,7 @@ func (c *Context) ButtonDisabled(id string, width float32, label string) {
 
 	// Draw button in disabled state
 	c.renderer.DrawRect(x, y, width, h, ColorButtonNormal.Darken(0.3))
-	c.renderer.DrawRectOutline(x, y, width, h, 1, ColorPanelBorder.Darken(0.3))
+	c.renderer.DrawRectOutline(x, y, width, h, 1, ColorButtonBorder.Darken(0.3))
 
 	// Draw button label centered (dimmed)
 	scale := float32(2.0)

--- a/internal/engine/ui2d/renderer.go
+++ b/internal/engine/ui2d/renderer.go
@@ -160,19 +160,10 @@ func (r *Renderer) End() {
 
 	proj := r.orthoMatrix(0, float32(r.screenWidth), float32(r.screenHeight), 0, -1, 1)
 
-	// Render solid quads first
-	if len(r.solidVertices) > 0 {
-		gl.UseProgram(r.solidShader)
-		projLoc := gl.GetUniformLocation(r.solidShader, gl.Str("uProjection\x00"))
-		gl.UniformMatrix4fv(projLoc, 1, false, &proj[0])
-
-		gl.BindVertexArray(r.solidVAO)
-		gl.BindBuffer(gl.ARRAY_BUFFER, r.solidVBO)
-		gl.BufferData(gl.ARRAY_BUFFER, len(r.solidVertices)*4, unsafe.Pointer(&r.solidVertices[0]), gl.STREAM_DRAW)
-		gl.DrawArrays(gl.TRIANGLES, 0, int32(len(r.solidVertices)/7)) // 7 floats per vertex
-	}
-
-	// Render image quads (UI textures) between solid and text
+	// Render image quads first (window skins, scene textures, etc).
+	// Solid quads paint on top so structural rectangles — buttons, input
+	// fields, separators — aren't buried under skin backgrounds. Order is:
+	//   image -> solid -> text.
 	if len(r.imageDrawCalls) > 0 {
 		gl.UseProgram(r.imageShader)
 		projLoc := gl.GetUniformLocation(r.imageShader, gl.Str("uProjection\x00"))
@@ -190,6 +181,18 @@ func (r *Renderer) End() {
 			gl.BindTexture(gl.TEXTURE_2D, dc.textureID)
 			gl.DrawArrays(gl.TRIANGLES, int32(dc.vertStart), int32(dc.vertCount))
 		}
+	}
+
+	// Solid quads on top of images.
+	if len(r.solidVertices) > 0 {
+		gl.UseProgram(r.solidShader)
+		projLoc := gl.GetUniformLocation(r.solidShader, gl.Str("uProjection\x00"))
+		gl.UniformMatrix4fv(projLoc, 1, false, &proj[0])
+
+		gl.BindVertexArray(r.solidVAO)
+		gl.BindBuffer(gl.ARRAY_BUFFER, r.solidVBO)
+		gl.BufferData(gl.ARRAY_BUFFER, len(r.solidVertices)*4, unsafe.Pointer(&r.solidVertices[0]), gl.STREAM_DRAW)
+		gl.DrawArrays(gl.TRIANGLES, 0, int32(len(r.solidVertices)/7)) // 7 floats per vertex
 	}
 
 	// Render textured quads (text) on top


### PR DESCRIPTION
## Summary

Two bugs and a polish step in one PR — they're entangled.

### The headline: render layer order was wrong

`Renderer.End()` drew **solid → image → text**. That layered the window-skin image on top of every `DrawRect` call inside the window, hiding the button background, input box backgrounds, dividers — basically everything structural. Text survived because it rendered last on top of all of it.

The bug was invisible until Polish step 2 here tried to give buttons a light-gray fill: with the old dark-blue button colour you couldn't tell the rectangle was buried, you just saw "dark-on-dark text" and assumed it was the button. Light-on-white made the missing rectangle obvious.

Fix: reorder to **image → solid → text** so widgets paint on top of their skin background.

### Polish step 2: raised buttons

Visible now that the layer fix lets them render:
- Light-gray fill (0.84) — distinguishable from the white BMP body and lets the bevel highlight register against it
- Bevel: white top/left, dark bottom/right (Win95-style raised look). Swapped on press for "pushed in" feedback.
- Hover/active fill tints blue, echoing the RO title bar accent (rgb 53, 93, 204).

## Side effect (next polish item)

The dark `ColorInputBg` (RGB ~0.05) was previously hidden under the skin too. Now it's visible — and looks harsh against the white body. Will tune in a follow-up PR (probably to white fill + recessed bevel, mirroring the button bevel inverted).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/engine/ui2d/... ./internal/game/ui/...` pass
- [x] `gofmt` clean
- [x] Manual: launch client, Login button visible as gray rectangle with bevel, hover tints blue, click works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)