### PR TITLE
feat(ui2d): bridge text input + restyle input fields

### DIFF
--- a/internal/engine/ui2d/color.go
+++ b/internal/engine/ui2d/color.go
@@ -36,8 +36,12 @@ var (
 	ColorButtonBorder  = Color{0.40, 0.40, 0.45, 1}
 	ColorButtonBevelHi = Color{1.00, 1.00, 1.00, 1}
 	ColorButtonBevelLo = Color{0.30, 0.30, 0.35, 1}
-	ColorInputBg       = Color{0.05, 0.05, 0.08, 1}
-	ColorInputBorder   = Color{0.2, 0.2, 0.3, 1}
+	// Input fields: white fill on the white BMP body, recessed bevel
+	// (inverted from buttons — dark on top/left, light on bottom/right).
+	// Focused border tints blue (RO accent rgb 53,93,204).
+	ColorInputBg          = Color{1.00, 1.00, 1.00, 1}
+	ColorInputBorder      = Color{0.55, 0.55, 0.58, 1}
+	ColorInputBorderFocus = Color{0.21, 0.36, 0.80, 1}
 	// ColorText is the default text color, tuned for legibility on the cream
 	// win_msgbox.bmp body (which is the dominant text surface).
 	ColorText       = Color{0.1, 0.1, 0.15, 1}

--- a/internal/engine/ui2d/context.go
+++ b/internal/engine/ui2d/context.go
@@ -350,13 +350,7 @@ func (c *Context) TextInput(id string, width float32, value string) (string, boo
 		}
 	}
 
-	// Draw input field
-	c.renderer.DrawRect(x, y, width, h, ColorInputBg)
-	borderColor := ColorInputBorder
-	if focused {
-		borderColor = ColorHighlight
-	}
-	c.renderer.DrawRectOutline(x, y, width, h, 1, borderColor)
+	drawSunkenInput(c.renderer, x, y, width, h, focused)
 
 	// Draw text value
 	scale := float32(2.0)
@@ -374,6 +368,23 @@ func (c *Context) TextInput(id string, width float32, value string) (string, boo
 	c.cursorX += width + 4
 
 	return value, changed, submitted
+}
+
+// drawSunkenInput renders a text-input field as a recessed (sunken) box on
+// the white BMP body: white fill plus a 1-pixel inverse bevel — dark on
+// top/left, light on bottom/right — so it reads as inset rather than raised.
+// Focused fields tint the border blue (RO accent).
+func drawSunkenInput(r *Renderer, x, y, width, h float32, focused bool) {
+	r.DrawRect(x, y, width, h, ColorInputBg)
+	border := ColorInputBorder
+	if focused {
+		border = ColorInputBorderFocus
+	}
+	// Inverse bevel: shadow on top/left, highlight on bottom/right.
+	r.DrawRect(x+1, y, width-2, 1, border)                 // top edge (shadow)
+	r.DrawRect(x, y+1, 1, h-2, border)                     // left edge
+	r.DrawRect(x+1, y+h-1, width-2, 1, ColorButtonBevelHi) // bottom edge (highlight)
+	r.DrawRect(x+width-1, y+1, 1, h-2, ColorButtonBevelHi) // right edge
 }
 
 // Spacer adds vertical space.
@@ -496,12 +507,7 @@ func (c *Context) PasswordInput(id string, width float32, value string) (string,
 	}
 
 	// Draw input field
-	c.renderer.DrawRect(x, y, width, h, ColorInputBg)
-	borderColor := ColorInputBorder
-	if focused {
-		borderColor = ColorHighlight
-	}
-	c.renderer.DrawRectOutline(x, y, width, h, 1, borderColor)
+	drawSunkenInput(c.renderer, x, y, width, h, focused)
 
 	// Draw masked text (dots instead of characters)
 	scale := float32(2.0)

--- a/internal/game/ui/ui2d_backend.go
+++ b/internal/game/ui/ui2d_backend.go
@@ -3,6 +3,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/AllenDang/cimgui-go/imgui"
 	"github.com/go-gl/gl/v4.1-core/gl"
@@ -103,6 +104,20 @@ func (b *UI2DBackend) syncInputFromImGui() {
 	in.KeyEnter = imgui.IsKeyDown(imgui.KeyEnter)
 	in.KeyEscape = imgui.IsKeyDown(imgui.KeyEscape)
 	in.KeyTab = imgui.IsKeyDown(imgui.KeyTab)
+
+	// Bridge ImGui's per-frame character input queue into ui2d's TextInput
+	// so users can type into our text fields. ImGui already translates
+	// SDL2 SDL_TEXTINPUT events into Wchars on its IO; we just consume the
+	// queue. Non-ASCII Wchars become multi-byte UTF-8 via rune conversion.
+	if chars := io.InputQueueCharacters().Slice(); len(chars) > 0 {
+		var buf strings.Builder
+		for _, ch := range chars {
+			if ch >= 32 { // skip control chars; backspace/enter handled via key flags
+				buf.WriteRune(rune(ch))
+			}
+		}
+		in.TextInput += buf.String()
+	}
 }
 
 // syncViewportSize keeps the ui2d renderer matched to ImGui's viewport size,


### PR DESCRIPTION
## Summary

Login form is now usable end-to-end via the new ui2d backend.

### Text input bridging

ImGui's per-frame `InputQueueCharacters` (which it populates from SDL2 SDL_TEXTINPUT events) drains into `ui2d.InputState.TextInput` each frame. Users can finally type into username/password fields. Backspace/Enter/Escape continue to flow through the existing key flags.

### Input field restyling

The old `ColorInputBg` (near-black) + 1px outline produced dark holes that clashed with the white BMP body. New look:
- White fill matching the body
- Recessed (sunken) bevel — inverted from the button bevel: dark on top/left, light on bottom/right
- New `ColorInputBorderFocus` tints the border RO blue (rgb 53, 93, 204) when focused

Both `TextInput` and `PasswordInput` share a new `drawSunkenInput` helper.

## Out of scope

- Bitmap font is still chunky — TTF integration is the next polish PR (highest visible impact remaining).
- Glass button refinement (gradient + chamfered corners) — earlier attempts were too subtle to perceive; will revisit after TTF lands so the button styling reads at a finer level.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/engine/ui2d/... ./internal/game/ui/...` pass
- [x] `gofmt` clean
- [x] Manual: launch client, click in username field, type — characters appear. Tab/click password, type — masked characters appear. Click Login → connects to server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)