### PR TITLE
fix(grftool): extract Korean-path files via EUC-KR fallback

### DIFF
--- a/cmd/grftool/main.go
+++ b/cmd/grftool/main.go
@@ -9,8 +9,23 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Faultbox/midgard-ro/pkg/encoding"
 	"github.com/Faultbox/midgard-ro/pkg/grf"
 )
+
+// resolvePath returns the in-archive path for a UTF-8 input, falling back
+// to EUC-KR encoding if the verbatim path doesn't exist (RO GRFs store
+// Korean directory names — like 유저인터페이스 — as raw EUC-KR bytes, so a
+// UTF-8 path with the same logical Korean characters won't find anything).
+func resolvePath(a *grf.Archive, path string) (string, bool) {
+	if a.Contains(path) {
+		return path, true
+	}
+	if euckr := string(encoding.UTF8ToEUCKR(path)); euckr != path && a.Contains(euckr) {
+		return euckr, true
+	}
+	return path, false
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -185,12 +200,13 @@ func cmdExtract(args []string) {
 	}
 
 	// Single file extraction
-	if !archive.Contains(filePath) {
+	resolved, ok := resolvePath(archive, filePath)
+	if !ok {
 		fmt.Fprintf(os.Stderr, "File not found: %s\n", filePath)
 		os.Exit(1)
 	}
 
-	data, err := archive.Read(filePath)
+	data, err := archive.Read(resolved)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading file: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

GRFs store Korean directory names (e.g. \`유저인터페이스\`) as raw EUC-KR bytes. The grftool's \`extract\` command did a verbatim \`archive.Contains()\` check on the user-supplied UTF-8 path, which never matched these EUC-KR-encoded entries. Result: any extract under a Korean folder failed with \`File not found\`, even though \`grftool list\` clearly showed the file existed.

This adds a \`resolvePath\` helper that retries the lookup with the path encoded as EUC-KR — the same fallback the in-game asset loader uses ([internal/assets/assets.go](internal/assets/assets.go)).

## Why now

This was the actual blocker when surveying GRF login-screen assets — without the fallback, you had to construct the raw EUC-KR byte sequence by hand to grab \`win_login.bmp\` / \`bt_start_*.bmp\` / etc.

## Test plan
- [ ] \`go build ./cmd/grftool/...\` clean
- [ ] \`grftool extract data.grf 'data/texture/유저인터페이스/win_msgbox.bmp' /tmp\` succeeds
- [ ] \`grftool extract data.grf 'data/non_existent.bmp' /tmp\` still reports \`File not found\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)